### PR TITLE
Changed parser to allow combinatorial expressions as condition in if expression

### DIFF
--- a/csv-validator-core/src/main/scala/uk/gov/tna/dri/schema/SchemaParser.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/tna/dri/schema/SchemaParser.scala
@@ -91,7 +91,10 @@ trait SchemaParser extends RegexParsers {
 
   def columnDirective = positioned(optional | ignoreCase | warning)
 
-  def rule = positioned( and | or | nonConditionalRule | conditionalRule)
+  def rule = positioned(  combinatorialAndNonConditionalRule | conditionalRule)
+
+  def combinatorialAndNonConditionalRule = (and | or | nonConditionalRule)
+
 
   // def nonConditionalRule = unaryRule
   def nonConditionalRule = opt( "$" ~> columnIdentifier <~ "/") ~ unaryRule ^^ { case explicitColumn ~ rule => rule.explicitColumn = explicitColumn; rule }
@@ -111,7 +114,7 @@ trait SchemaParser extends RegexParsers {
 
   def and: Parser[AndRule] = nonConditionalRule ~ "and" ~ rule  ^^  { case lhs ~ _ ~ rhs =>  AndRule(lhs, rhs) }
 
-  def ifExpr: Parser[IfRule] = (("if(" ~> white ~> nonConditionalRule <~ white <~ "," <~ white) ~ (rep1(rule)) ~ opt((white ~> "," ~> white ~> rep1(rule))) <~ white <~ ")" ^^ {
+  def ifExpr: Parser[IfRule] = (("if(" ~> white ~> combinatorialAndNonConditionalRule <~ white <~ "," <~ white) ~ (rep1(rule)) ~ opt((white ~> "," ~> white ~> rep1(rule))) <~ white <~ ")" ^^ {
     case cond ~ bdy ~ optBdy => IfRule(cond, bdy, optBdy)
   }) | failure("Invalid rule")
 

--- a/csv-validator-core/src/test/scala/uk/gov/tna/dri/validator/MetaDataValidatorSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/tna/dri/validator/MetaDataValidatorSpec.scala
@@ -1042,6 +1042,16 @@ class MetaDataValidatorSpec extends Specification {
       validate(metaData, schema) must beLike { case Success(_) => ok }
     }
 
+    "succeed for simple if with combinator" in {
+      val schema =
+        """version 1.0
+           @totalColumns 1 @noHeader
+           col1: if(starts("Tom") or starts("Joe"), ends("Bloggs") )
+        """
+      val metaData ="Joe Bloggs"
+      validate(metaData, schema) must beLike { case Success(_) => ok }
+    }
+
     "succeed for simple if where condition is true" in {
       val schema =
         """version 1.0


### PR DESCRIPTION
I have modified the parser so that the if expression can now handle combinatorial expressions as the condition:

if(starts("a") or starts("b"), ends("10"))

I think that the SchemaParser should be re-written so that it matches the grammar.
