### PR TITLE
Add explicit row line number and column index to the FailMessage.

### DIFF
--- a/csv-validator-cmd/src/main/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdApp.scala
+++ b/csv-validator-cmd/src/main/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdApp.scala
@@ -113,9 +113,9 @@ object CsvValidatorCmdApp extends App {
 
   private def prettyPrint(l: NonEmptyList[FailMessage]): String = l.list.map{i =>
     i match {
-      case WarningMessage(err) => "Warning: " + err
-      case ErrorMessage(err) =>   "Error:   " + err
-      case SchemaMessage(err) =>  err
+      case WarningMessage(err,_,_) => "Warning: " + err
+      case ErrorMessage(err,_,_) =>   "Error:   " + err
+      case SchemaMessage(err,_,_) =>  err
     }
   }.mkString(sys.props("line.separator"))
 }

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/AllErrorsMetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/AllErrorsMetaDataValidator.scala
@@ -48,7 +48,7 @@ trait AllErrorsMetaDataValidator extends MetaDataValidator {
     }
 
     if (tc.isEmpty || tc.get.numberOfColumns == row.cells.length) true.successNel[FailMessage]
-    else ErrorMessage(s"Expected @totalColumns of ${tc.get.numberOfColumns} and found ${row.cells.length} on line ${row.lineNumber}", row.lineNumber).failNel[Any]
+    else ErrorMessage(s"Expected @totalColumns of ${tc.get.numberOfColumns} and found ${row.cells.length} on line ${row.lineNumber}", Some(row.lineNumber)).failNel[Any]
   }
 
   private def rules(row: Row, schema: Schema): MetaDataValidation[List[Any]] = {
@@ -60,7 +60,7 @@ trait AllErrorsMetaDataValidator extends MetaDataValidator {
   private def validateCell(columnIndex: Int, cells: (Int) => Option[Cell], row: Row, schema: Schema): MetaDataValidation[Any] = {
     cells(columnIndex) match {
       case Some(c) => rulesForCell(columnIndex, row, schema)
-      case _ => ErrorMessage(s"Missing value at line: ${row.lineNumber}, column: ${schema.columnDefinitions(columnIndex).id}", row.lineNumber, columnIndex).failNel[Any]
+      case _ => ErrorMessage(s"Missing value at line: ${row.lineNumber}, column: ${schema.columnDefinitions(columnIndex).id}", Some(row.lineNumber), Some(columnIndex)).failNel[Any]
     }
   }
 
@@ -72,11 +72,11 @@ trait AllErrorsMetaDataValidator extends MetaDataValidator {
     def isOptionDirective: Boolean = columnDefinition.directives.contains(Optional())
 
     def convert2Warnings(results:Rule#RuleValidation[Any]): MetaDataValidation[Any] = {
-      results.leftMap(_.map(WarningMessage(_, row.lineNumber, columnIndex)))
+      results.leftMap(_.map(WarningMessage(_, Some(row.lineNumber), Some(columnIndex))))
     }
 
     def convert2Errors(results:Rule#RuleValidation[Any]): MetaDataValidation[Any] = {
-      results.leftMap(_.map(ErrorMessage(_, row.lineNumber, columnIndex)))
+      results.leftMap(_.map(ErrorMessage(_, Some(row.lineNumber), Some(columnIndex))))
     }
 
     if (row.cells(columnIndex).value.trim.isEmpty && isOptionDirective) true.successNel

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/AllErrorsMetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/AllErrorsMetaDataValidator.scala
@@ -48,7 +48,7 @@ trait AllErrorsMetaDataValidator extends MetaDataValidator {
     }
 
     if (tc.isEmpty || tc.get.numberOfColumns == row.cells.length) true.successNel[FailMessage]
-    else ErrorMessage(s"Expected @totalColumns of ${tc.get.numberOfColumns} and found ${row.cells.length} on line ${row.lineNumber}", row.lineNumber, row.cells.length).failNel[Any]
+    else ErrorMessage(s"Expected @totalColumns of ${tc.get.numberOfColumns} and found ${row.cells.length} on line ${row.lineNumber}", row.lineNumber).failNel[Any]
   }
 
   private def rules(row: Row, schema: Schema): MetaDataValidation[List[Any]] = {

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/AllErrorsMetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/AllErrorsMetaDataValidator.scala
@@ -48,7 +48,7 @@ trait AllErrorsMetaDataValidator extends MetaDataValidator {
     }
 
     if (tc.isEmpty || tc.get.numberOfColumns == row.cells.length) true.successNel[FailMessage]
-    else ErrorMessage(s"Expected @totalColumns of ${tc.get.numberOfColumns} and found ${row.cells.length} on line ${row.lineNumber}").failNel[Any]
+    else ErrorMessage(s"Expected @totalColumns of ${tc.get.numberOfColumns} and found ${row.cells.length} on line ${row.lineNumber}", row.lineNumber, row.cells.length).failNel[Any]
   }
 
   private def rules(row: Row, schema: Schema): MetaDataValidation[List[Any]] = {
@@ -60,7 +60,7 @@ trait AllErrorsMetaDataValidator extends MetaDataValidator {
   private def validateCell(columnIndex: Int, cells: (Int) => Option[Cell], row: Row, schema: Schema): MetaDataValidation[Any] = {
     cells(columnIndex) match {
       case Some(c) => rulesForCell(columnIndex, row, schema)
-      case _ => ErrorMessage(s"Missing value at line: ${row.lineNumber}, column: ${schema.columnDefinitions(columnIndex).id}").failNel[Any]
+      case _ => ErrorMessage(s"Missing value at line: ${row.lineNumber}, column: ${schema.columnDefinitions(columnIndex).id}", row.lineNumber, columnIndex).failNel[Any]
     }
   }
 
@@ -72,11 +72,11 @@ trait AllErrorsMetaDataValidator extends MetaDataValidator {
     def isOptionDirective: Boolean = columnDefinition.directives.contains(Optional())
 
     def convert2Warnings(results:Rule#RuleValidation[Any]): MetaDataValidation[Any] = {
-      results.leftMap(_.map(WarningMessage))
+      results.leftMap(_.map(WarningMessage(_, row.lineNumber, columnIndex)))
     }
 
     def convert2Errors(results:Rule#RuleValidation[Any]): MetaDataValidation[Any] = {
-      results.leftMap(_.map(ErrorMessage))
+      results.leftMap(_.map(ErrorMessage(_, row.lineNumber, columnIndex)))
     }
 
     if (row.cells(columnIndex).value.trim.isEmpty && isOptionDirective) true.successNel

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/FailFastMetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/FailFastMetaDataValidator.scala
@@ -68,7 +68,7 @@ trait FailFastMetaDataValidator extends MetaDataValidator {
     val tc: Option[TotalColumns] = schema.globalDirectives.collectFirst{ case t@TotalColumns(_) => t }
 
     if (tc.isEmpty || tc.get.numberOfColumns == row.cells.length) true.successNel[FailMessage]
-    else ErrorMessage(s"Expected @totalColumns of ${tc.get.numberOfColumns} and found ${row.cells.length} on line ${row.lineNumber}", row.lineNumber, row.cells.length).failNel[Any]
+    else ErrorMessage(s"Expected @totalColumns of ${tc.get.numberOfColumns} and found ${row.cells.length} on line ${row.lineNumber}", Some(row.lineNumber), Some(row.cells.length)).failNel[Any]
   }
 
   private def rules(row: Row, schema: Schema): MetaDataValidation[Any] = {
@@ -90,7 +90,7 @@ trait FailFastMetaDataValidator extends MetaDataValidator {
   private def validateCell(columnIndex: Int, cells: (Int) => Option[Cell], row: Row, schema: Schema): MetaDataValidation[Any] = {
     cells(columnIndex) match {
       case Some(c) => rulesForCell(columnIndex, row, schema)
-      case _ => SchemaMessage(s"Missing value at line: ${row.lineNumber}, column: ${schema.columnDefinitions(columnIndex).id}", row.lineNumber, columnIndex).failNel[Any]
+      case _ => SchemaMessage(s"Missing value at line: ${row.lineNumber}, column: ${schema.columnDefinitions(columnIndex).id}", Some(row.lineNumber), Some(columnIndex)).failNel[Any]
     }
   }
 
@@ -101,11 +101,11 @@ trait FailFastMetaDataValidator extends MetaDataValidator {
     def isOptionDirective: Boolean = columnDefinition.directives.contains(Optional())
 
     def convert2Warnings(results:Rule#RuleValidation[Any]): MetaDataValidation[Any] = {
-      results.leftMap(_.map(WarningMessage(_, row.lineNumber, columnIndex)))
+      results.leftMap(_.map(WarningMessage(_, Some(row.lineNumber), Some(columnIndex))))
     }
 
     def convert2Errors(results:Rule#RuleValidation[Any]): MetaDataValidation[Any] = {
-      results.leftMap(_.map(ErrorMessage(_, row.lineNumber, columnIndex)))
+      results.leftMap(_.map(ErrorMessage(_, Some(row.lineNumber), Some(columnIndex))))
     }
 
     @tailrec

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/FailFastMetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/FailFastMetaDataValidator.scala
@@ -68,7 +68,7 @@ trait FailFastMetaDataValidator extends MetaDataValidator {
     val tc: Option[TotalColumns] = schema.globalDirectives.collectFirst{ case t@TotalColumns(_) => t }
 
     if (tc.isEmpty || tc.get.numberOfColumns == row.cells.length) true.successNel[FailMessage]
-    else ErrorMessage(s"Expected @totalColumns of ${tc.get.numberOfColumns} and found ${row.cells.length} on line ${row.lineNumber}").failNel[Any]
+    else ErrorMessage(s"Expected @totalColumns of ${tc.get.numberOfColumns} and found ${row.cells.length} on line ${row.lineNumber}", row.lineNumber, row.cells.length).failNel[Any]
   }
 
   private def rules(row: Row, schema: Schema): MetaDataValidation[Any] = {
@@ -90,7 +90,7 @@ trait FailFastMetaDataValidator extends MetaDataValidator {
   private def validateCell(columnIndex: Int, cells: (Int) => Option[Cell], row: Row, schema: Schema): MetaDataValidation[Any] = {
     cells(columnIndex) match {
       case Some(c) => rulesForCell(columnIndex, row, schema)
-      case _ => SchemaMessage(s"Missing value at line: ${row.lineNumber}, column: ${schema.columnDefinitions(columnIndex).id}").failNel[Any]
+      case _ => SchemaMessage(s"Missing value at line: ${row.lineNumber}, column: ${schema.columnDefinitions(columnIndex).id}", row.lineNumber, columnIndex).failNel[Any]
     }
   }
 
@@ -101,11 +101,11 @@ trait FailFastMetaDataValidator extends MetaDataValidator {
     def isOptionDirective: Boolean = columnDefinition.directives.contains(Optional())
 
     def convert2Warnings(results:Rule#RuleValidation[Any]): MetaDataValidation[Any] = {
-      results.leftMap(_.map(WarningMessage))
+      results.leftMap(_.map(WarningMessage(_, row.lineNumber, columnIndex)))
     }
 
     def convert2Errors(results:Rule#RuleValidation[Any]): MetaDataValidation[Any] = {
-      results.leftMap(_.map(ErrorMessage))
+      results.leftMap(_.map(ErrorMessage(_, row.lineNumber, columnIndex)))
     }
 
     @tailrec

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidator.scala
@@ -20,9 +20,9 @@ import scala.annotation.tailrec
 import uk.gov.nationalarchives.csv.validator.api.TextFile
 
 sealed abstract class FailMessage(val msg:String, val lineNr:Int, val colIdx:Int)
-case class WarningMessage(message:String, lineNumber: Int, columnIndex: Int) extends FailMessage(message, lineNumber, columnIndex)
-case class ErrorMessage(message:String, lineNumber: Int, columnIndex: Int) extends FailMessage(message, lineNumber, columnIndex)
-case class SchemaMessage(message:String, lineNumber: Int = 0, columnIndex: Int = 0) extends FailMessage(message, lineNumber, columnIndex)
+case class WarningMessage(message:String, lineNumber: Int, columnIndex: Int = -1) extends FailMessage(message, lineNumber, columnIndex)
+case class ErrorMessage(message:String, lineNumber: Int, columnIndex: Int = -1) extends FailMessage(message, lineNumber, columnIndex)
+case class SchemaMessage(message:String, lineNumber: Int = 0, columnIndex: Int = -1) extends FailMessage(message, lineNumber, columnIndex)
 
 case class ProgressFor(rowsToValidate: Int, progress: ProgressCallback)
 

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidator.scala
@@ -19,10 +19,10 @@ import uk.gov.nationalarchives.csv.validator.metadata.Row
 import scala.annotation.tailrec
 import uk.gov.nationalarchives.csv.validator.api.TextFile
 
-sealed abstract class FailMessage(val msg:String)
-case class WarningMessage(message:String) extends FailMessage(message)
-case class ErrorMessage(message:String) extends FailMessage(message)
-case class SchemaMessage(message:String) extends FailMessage(message)
+sealed abstract class FailMessage(val msg:String, val lineNr:Int, val colIdx:Int)
+case class WarningMessage(message:String, lineNumber: Int, columnIndex: Int) extends FailMessage(message, lineNumber, columnIndex)
+case class ErrorMessage(message:String, lineNumber: Int, columnIndex: Int) extends FailMessage(message, lineNumber, columnIndex)
+case class SchemaMessage(message:String, lineNumber: Int = 0, columnIndex: Int = 0) extends FailMessage(message, lineNumber, columnIndex)
 
 case class ProgressFor(rowsToValidate: Int, progress: ProgressCallback)
 
@@ -77,17 +77,17 @@ trait MetaDataValidator {
         val maybeNoData =
           if (schema.globalDirectives.contains(NoHeader())) {
             if (!rowIt.hasNext && !schema.globalDirectives.contains(PermitEmpty())) {
-              Some(ErrorMessage("metadata file is empty but this has not been permitted").failNel[Any])
+              Some(ErrorMessage("metadata file is empty but this has not been permitted", 0,0).failNel[Any])
             } else {
               None
             }
           } else {
             if(!rowIt.hasNext) {
-              Some(ErrorMessage("metadata file is empty but should contain at least a header").failNel[Any])
+              Some(ErrorMessage("metadata file is empty but should contain at least a header", 0,0).failNel[Any])
             } else {
               val header = rowIt.skipHeader()
               if(!rowIt.hasNext && !schema.globalDirectives.contains(PermitEmpty())) {
-                Some(ErrorMessage("metadata file has a header but no data and this has not been permitted").failNel[Any])
+                Some(ErrorMessage("metadata file has a header but no data and this has not been permitted", 0,0).failNel[Any])
               } else {
                 None
               }
@@ -107,7 +107,7 @@ trait MetaDataValidator {
 
       case Left(ts) =>
         //TODO emit all errors not just first!
-        ErrorMessage(ts(0).toString).failNel[Any]
+        ErrorMessage(ts(0).toString, 0,0).failNel[Any]
         //ts.toList.map(t => ErrorMessage(t.toString).failNel[Any]).sequence[MetaDataValidation, Any]
     }
   }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
@@ -108,8 +108,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     "all be reported" in {
       validate(TextFile(Path.fromString(base) / "multipleErrorsMetaData.csv"), parse(base + "/regexRuleSchemaWithNoHeaderSet.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""regex("[0-9]+") fails for line: 1, column: Age, value: "twenty""""),
-          ErrorMessage("""regex("[0-9]+") fails for line: 2, column: Age, value: "thirty""""))
+          ErrorMessage("""regex("[0-9]+") fails for line: 1, column: Age, value: "twenty"""",1,1),
+          ErrorMessage("""regex("[0-9]+") fails for line: 2, column: Age, value: "thirty"""",2,1))
       }
     }
   }
@@ -124,10 +124,10 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     "fail when rules fail for all permutations" in {
       validate(TextFile(Path.fromString(base) / "twoRulesFailMetaData.csv"), parse(base + "/twoRuleSchemaFail.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""in($FullName) fails for line: 1, column: Name, value: "Ben""""),
-          ErrorMessage("""regex("[a-z]+") fails for line: 1, column: Name, value: "Ben""""),
-          ErrorMessage("""in($FullName) fails for line: 2, column: Name, value: "Dave""""),
-          ErrorMessage("""regex("[a-z]+") fails for line: 2, column: Name, value: "Dave""""))
+          ErrorMessage("""in($FullName) fails for line: 1, column: Name, value: "Ben"""",1,0),
+          ErrorMessage("""regex("[a-z]+") fails for line: 1, column: Name, value: "Ben"""",1,0),
+          ErrorMessage("""in($FullName) fails for line: 2, column: Name, value: "Dave"""",2,0),
+          ErrorMessage("""regex("[a-z]+") fails for line: 2, column: Name, value: "Dave"""",2,0))
       }
     }
   }
@@ -142,8 +142,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     "fail if the column value is not in the rule's literal string" in {
       validate(TextFile(Path.fromString(base) / "inRuleFailMetaData.csv"), parse(base + "/inRuleSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""in("thevaluemustbeinthisstring") fails for line: 1, column: SomeInRule, value: "valuenotinrule""""),
-          ErrorMessage("""in("thevaluemustbeinthisstring") fails for line: 3, column: SomeInRule, value: "thisonewillfailtoo""""))
+          ErrorMessage("""in("thevaluemustbeinthisstring") fails for line: 1, column: SomeInRule, value: "valuenotinrule"""",1,1),
+          ErrorMessage("""in("thevaluemustbeinthisstring") fails for line: 3, column: SomeInRule, value: "thisonewillfailtoo"""",3,1))
       }
     }
 
@@ -155,7 +155,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if the column value is not in the rule's cross referenced column" in {
       validate(TextFile(Path.fromString(base) / "inRuleCrossReferenceFailMetaData.csv"), parse(base + "/inRuleCrossReferenceSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""in($FullName) fails for line: 2, column: FirstName, value: "Dave""""))
+        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""in($FullName) fails for line: 2, column: FirstName, value: "Dave"""",2,0))
       }
     }
   }
@@ -169,7 +169,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if a non empty value fails a rule" in {
       validate(TextFile(Path.fromString(base) / "optionalFailMetaData.csv"), parse(base + "/optionalSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("in($FullName) fails for line: 1, column: Name, value: \"BP\""))
+        case Failure(errors) => errors.list mustEqual List(ErrorMessage("in($FullName) fails for line: 1, column: Name, value: \"BP\"",1,0))
       }
     }
   }
@@ -208,8 +208,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     "fail if the file does not exist on the file system" in {
       validate(TextFile(Path.fromString(base) / "fileExistsPassMetaData.csv"), parse(base + "/fileExistsSchemaWithBadBasePath.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""fileExists("src/test/resources/uk/gov/nationalarchives") fails for line: 1, column: PasswordFile, value: "benPass.csvs""""),
-          ErrorMessage("""fileExists("src/test/resources/uk/gov/nationalarchives") fails for line: 2, column: PasswordFile, value: "andyPass.csvs""""))
+          ErrorMessage("""fileExists("src/test/resources/uk/gov/nationalarchives") fails for line: 1, column: PasswordFile, value: "benPass.csvs"""",1,2),
+          ErrorMessage("""fileExists("src/test/resources/uk/gov/nationalarchives") fails for line: 2, column: PasswordFile, value: "andyPass.csvs"""",2,2))
       }
     }
 
@@ -221,8 +221,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
       validateE(TextFile(Path.fromString(base) / "caseSensitiveFiles.csv"), parseE(new StringReader(csfSchema)), None) must beLike {
         case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""fileExists("$$acceptance$$") fails for line: 2, column: filename, value: "casesensitivefiles.csv"""".replace("$$acceptance$$", base)),
-          ErrorMessage("""fileExists("$$acceptance$$") fails for line: 3, column: filename, value: "CASESENSITIVEFILES.csv"""".replace("$$acceptance$$", base))
+          ErrorMessage("""fileExists("$$acceptance$$") fails for line: 2, column: filename, value: "casesensitivefiles.csv"""".replace("$$acceptance$$", base),2,0),
+          ErrorMessage("""fileExists("$$acceptance$$") fails for line: 3, column: filename, value: "CASESENSITIVEFILES.csv"""".replace("$$acceptance$$", base),3,0)
         )
       }
     }
@@ -238,8 +238,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
       validateE(TextFile(Path.fromString(base) / "caseSensitiveFilesChecksum.csv"), parseE(new StringReader(csfSchema)), None) must beLike {
         case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""checksum(file("$$acceptance$$", $filename), "MD5") file "$$acceptance$$$$file-sep$$casesensitivefileschecksum.csvs" not found for line: 2, column: checksum, value: "41424313f6052b7f062358ed38640b6e"""".replace("$$acceptance$$", base).replace("$$file-sep$$", FILE_SEPARATOR.toString)),
-          ErrorMessage("""checksum(file("$$acceptance$$", $filename), "MD5") file "$$acceptance$$$$file-sep$$CASESENSITIVEFILESCHECKSUM.csvs" not found for line: 3, column: checksum, value: "41424313f6052b7f062358ed38640b6e"""".replace("$$acceptance$$", base).replace("$$file-sep$$", FILE_SEPARATOR.toString))
+          ErrorMessage("""checksum(file("$$acceptance$$", $filename), "MD5") file "$$acceptance$$$$file-sep$$casesensitivefileschecksum.csvs" not found for line: 2, column: checksum, value: "41424313f6052b7f062358ed38640b6e"""".replace("$$acceptance$$", base).replace("$$file-sep$$", FILE_SEPARATOR.toString),2,1),
+          ErrorMessage("""checksum(file("$$acceptance$$", $filename), "MD5") file "$$acceptance$$$$file-sep$$CASESENSITIVEFILESCHECKSUM.csvs" not found for line: 3, column: checksum, value: "41424313f6052b7f062358ed38640b6e"""".replace("$$acceptance$$", base).replace("$$file-sep$$", FILE_SEPARATOR.toString),3,1)
         )
       }
     }
@@ -250,13 +250,13 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "only report first error for invalid @TotalColumns" in {
       app.validate(TextFile(Path.fromString(base) / "totalColumnsFailMetaData.csv"), parse(base + "/totalColumnsSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("Expected @totalColumns of 1 and found 2 on line 2"))
+        case Failure(errors) => errors.list mustEqual List(ErrorMessage("Expected @totalColumns of 1 and found 2 on line 2",2,2))
       }
     }
 
     "only report first rule fail for multiple rules on a column" in {
       app.validate(TextFile(Path.fromString(base) / "rulesFailMetaData.csv"), parse(base + "/rulesSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z][a-z]+") fails for line: 2, column: Name, value: "ben""""))
+        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z][a-z]+") fails for line: 2, column: Name, value: "ben"""",2,0))
       }
     }
 
@@ -299,7 +299,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if both the lhs or rhs are fail" in {
       validate(TextFile(Path.fromString(base) / "orWithTwoRulesFailMetaData.csv"), parse(base + "/orWithTwoRulesSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z][a-z]+") or regex("[0-9]+") fails for line: 4, column: CountryOrCountryCode, value: "Andromeda9""""))
+        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z][a-z]+") or regex("[0-9]+") fails for line: 4, column: CountryOrCountryCode, value: "Andromeda9"""",4,1))
       }
     }
 
@@ -311,7 +311,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if 'or' rules pass and 'and' rule fails" in {
       validate(TextFile(Path.fromString(base) / "orWithFourRulesFailMetaData.csv"), parse(base + "/orWithFourRulesSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z].+") fails for line: 2, column: Country, value: "ngland""""))
+        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z].+") fails for line: 2, column: Country, value: "ngland"""",2,1))
       }
     }
   }
@@ -325,7 +325,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if all the rules are not" in {
       validate(TextFile(Path.fromString(base) / "standardRulesFailMetaData.csv"), parse(base + "/standardRulesSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list.toString() mustEqual """List(ErrorMessage(uri fails for line: 1, column: uri, value: "http:##datagov.nationalarchives.gov.uk#66#WO#409#9999#0#aaaaaaaa-aaaa-4aaa-9eee-0123456789ab"), ErrorMessage(xDateTime fails for line: 1, column: xDateTime, value: "2002-999-30T09:00:10"), ErrorMessage(xDate fails for line: 1, column: xDate, value: "02-99-30"), ErrorMessage(ukDate fails for line: 1, column: ukDate, value: "99/00/0009"), ErrorMessage(xTime fails for line: 1, column: xTime, value: "99:00:889"), ErrorMessage(uuid4 fails for line: 1, column: uuid4, value: "aaaaaaaab-aaaab-4aaa-9eee-0123456789ab"), ErrorMessage(positiveInteger fails for line: 1, column: positiveInteger, value: "12-0912459"))"""
+        case Failure(errors) => errors.list.toString() mustEqual """List(ErrorMessage(uri fails for line: 1, column: uri, value: "http:##datagov.nationalarchives.gov.uk#66#WO#409#9999#0#aaaaaaaa-aaaa-4aaa-9eee-0123456789ab",1,0), ErrorMessage(xDateTime fails for line: 1, column: xDateTime, value: "2002-999-30T09:00:10",1,1), ErrorMessage(xDate fails for line: 1, column: xDate, value: "02-99-30",1,2), ErrorMessage(ukDate fails for line: 1, column: ukDate, value: "99/00/0009",1,3), ErrorMessage(xTime fails for line: 1, column: xTime, value: "99:00:889",1,4), ErrorMessage(uuid4 fails for line: 1, column: uuid4, value: "aaaaaaaab-aaaab-4aaa-9eee-0123456789ab",1,5), ErrorMessage(positiveInteger fails for line: 1, column: positiveInteger, value: "12-0912459",1,6))"""
 
       }
     }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
@@ -108,8 +108,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     "all be reported" in {
       validate(TextFile(Path.fromString(base) / "multipleErrorsMetaData.csv"), parse(base + "/regexRuleSchemaWithNoHeaderSet.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""regex("[0-9]+") fails for line: 1, column: Age, value: "twenty"""",1,1),
-          ErrorMessage("""regex("[0-9]+") fails for line: 2, column: Age, value: "thirty"""",2,1))
+          ErrorMessage("""regex("[0-9]+") fails for line: 1, column: Age, value: "twenty"""",Some(1),Some(1)),
+          ErrorMessage("""regex("[0-9]+") fails for line: 2, column: Age, value: "thirty"""",Some(2),Some(1)))
       }
     }
   }
@@ -124,10 +124,10 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     "fail when rules fail for all permutations" in {
       validate(TextFile(Path.fromString(base) / "twoRulesFailMetaData.csv"), parse(base + "/twoRuleSchemaFail.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""in($FullName) fails for line: 1, column: Name, value: "Ben"""",1,0),
-          ErrorMessage("""regex("[a-z]+") fails for line: 1, column: Name, value: "Ben"""",1,0),
-          ErrorMessage("""in($FullName) fails for line: 2, column: Name, value: "Dave"""",2,0),
-          ErrorMessage("""regex("[a-z]+") fails for line: 2, column: Name, value: "Dave"""",2,0))
+          ErrorMessage("""in($FullName) fails for line: 1, column: Name, value: "Ben"""",Some(1),Some(0)),
+          ErrorMessage("""regex("[a-z]+") fails for line: 1, column: Name, value: "Ben"""",Some(1),Some(0)),
+          ErrorMessage("""in($FullName) fails for line: 2, column: Name, value: "Dave"""",Some(2),Some(0)),
+          ErrorMessage("""regex("[a-z]+") fails for line: 2, column: Name, value: "Dave"""",Some(2),Some(0)))
       }
     }
   }
@@ -142,8 +142,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     "fail if the column value is not in the rule's literal string" in {
       validate(TextFile(Path.fromString(base) / "inRuleFailMetaData.csv"), parse(base + "/inRuleSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""in("thevaluemustbeinthisstring") fails for line: 1, column: SomeInRule, value: "valuenotinrule"""",1,1),
-          ErrorMessage("""in("thevaluemustbeinthisstring") fails for line: 3, column: SomeInRule, value: "thisonewillfailtoo"""",3,1))
+          ErrorMessage("""in("thevaluemustbeinthisstring") fails for line: 1, column: SomeInRule, value: "valuenotinrule"""",Some(1),Some(1)),
+          ErrorMessage("""in("thevaluemustbeinthisstring") fails for line: 3, column: SomeInRule, value: "thisonewillfailtoo"""",Some(3),Some(1)))
       }
     }
 
@@ -155,7 +155,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if the column value is not in the rule's cross referenced column" in {
       validate(TextFile(Path.fromString(base) / "inRuleCrossReferenceFailMetaData.csv"), parse(base + "/inRuleCrossReferenceSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""in($FullName) fails for line: 2, column: FirstName, value: "Dave"""",2,0))
+        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""in($FullName) fails for line: 2, column: FirstName, value: "Dave"""",Some(2),Some(0)))
       }
     }
   }
@@ -169,7 +169,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if a non empty value fails a rule" in {
       validate(TextFile(Path.fromString(base) / "optionalFailMetaData.csv"), parse(base + "/optionalSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("in($FullName) fails for line: 1, column: Name, value: \"BP\"",1,0))
+        case Failure(errors) => errors.list mustEqual List(ErrorMessage("in($FullName) fails for line: 1, column: Name, value: \"BP\"",Some(1),Some(0)))
       }
     }
   }
@@ -208,8 +208,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     "fail if the file does not exist on the file system" in {
       validate(TextFile(Path.fromString(base) / "fileExistsPassMetaData.csv"), parse(base + "/fileExistsSchemaWithBadBasePath.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""fileExists("src/test/resources/uk/gov/nationalarchives") fails for line: 1, column: PasswordFile, value: "benPass.csvs"""",1,2),
-          ErrorMessage("""fileExists("src/test/resources/uk/gov/nationalarchives") fails for line: 2, column: PasswordFile, value: "andyPass.csvs"""",2,2))
+          ErrorMessage("""fileExists("src/test/resources/uk/gov/nationalarchives") fails for line: 1, column: PasswordFile, value: "benPass.csvs"""",Some(1),Some(2)),
+          ErrorMessage("""fileExists("src/test/resources/uk/gov/nationalarchives") fails for line: 2, column: PasswordFile, value: "andyPass.csvs"""",Some(2),Some(2)))
       }
     }
 
@@ -221,8 +221,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
       validateE(TextFile(Path.fromString(base) / "caseSensitiveFiles.csv"), parseE(new StringReader(csfSchema)), None) must beLike {
         case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""fileExists("$$acceptance$$") fails for line: 2, column: filename, value: "casesensitivefiles.csv"""".replace("$$acceptance$$", base),2,0),
-          ErrorMessage("""fileExists("$$acceptance$$") fails for line: 3, column: filename, value: "CASESENSITIVEFILES.csv"""".replace("$$acceptance$$", base),3,0)
+          ErrorMessage("""fileExists("$$acceptance$$") fails for line: 2, column: filename, value: "casesensitivefiles.csv"""".replace("$$acceptance$$", base),Some(2),Some(0)),
+          ErrorMessage("""fileExists("$$acceptance$$") fails for line: 3, column: filename, value: "CASESENSITIVEFILES.csv"""".replace("$$acceptance$$", base),Some(3),Some(0))
         )
       }
     }
@@ -238,8 +238,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
       validateE(TextFile(Path.fromString(base) / "caseSensitiveFilesChecksum.csv"), parseE(new StringReader(csfSchema)), None) must beLike {
         case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""checksum(file("$$acceptance$$", $filename), "MD5") file "$$acceptance$$$$file-sep$$casesensitivefileschecksum.csvs" not found for line: 2, column: checksum, value: "41424313f6052b7f062358ed38640b6e"""".replace("$$acceptance$$", base).replace("$$file-sep$$", FILE_SEPARATOR.toString),2,1),
-          ErrorMessage("""checksum(file("$$acceptance$$", $filename), "MD5") file "$$acceptance$$$$file-sep$$CASESENSITIVEFILESCHECKSUM.csvs" not found for line: 3, column: checksum, value: "41424313f6052b7f062358ed38640b6e"""".replace("$$acceptance$$", base).replace("$$file-sep$$", FILE_SEPARATOR.toString),3,1)
+          ErrorMessage("""checksum(file("$$acceptance$$", $filename), "MD5") file "$$acceptance$$$$file-sep$$casesensitivefileschecksum.csvs" not found for line: 2, column: checksum, value: "41424313f6052b7f062358ed38640b6e"""".replace("$$acceptance$$", base).replace("$$file-sep$$", FILE_SEPARATOR.toString),Some(2),Some(1)),
+          ErrorMessage("""checksum(file("$$acceptance$$", $filename), "MD5") file "$$acceptance$$$$file-sep$$CASESENSITIVEFILESCHECKSUM.csvs" not found for line: 3, column: checksum, value: "41424313f6052b7f062358ed38640b6e"""".replace("$$acceptance$$", base).replace("$$file-sep$$", FILE_SEPARATOR.toString),Some(3),Some(1))
         )
       }
     }
@@ -250,13 +250,13 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "only report first error for invalid @TotalColumns" in {
       app.validate(TextFile(Path.fromString(base) / "totalColumnsFailMetaData.csv"), parse(base + "/totalColumnsSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("Expected @totalColumns of 1 and found 2 on line 2",2,2))
+        case Failure(errors) => errors.list mustEqual List(ErrorMessage("Expected @totalColumns of 1 and found 2 on line 2",Some(2),Some(2)))
       }
     }
 
     "only report first rule fail for multiple rules on a column" in {
       app.validate(TextFile(Path.fromString(base) / "rulesFailMetaData.csv"), parse(base + "/rulesSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z][a-z]+") fails for line: 2, column: Name, value: "ben"""",2,0))
+        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z][a-z]+") fails for line: 2, column: Name, value: "ben"""",Some(2),Some(0)))
       }
     }
 
@@ -299,7 +299,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if both the lhs or rhs are fail" in {
       validate(TextFile(Path.fromString(base) / "orWithTwoRulesFailMetaData.csv"), parse(base + "/orWithTwoRulesSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z][a-z]+") or regex("[0-9]+") fails for line: 4, column: CountryOrCountryCode, value: "Andromeda9"""",4,1))
+        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z][a-z]+") or regex("[0-9]+") fails for line: 4, column: CountryOrCountryCode, value: "Andromeda9"""",Some(4),Some(1)))
       }
     }
 
@@ -311,7 +311,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if 'or' rules pass and 'and' rule fails" in {
       validate(TextFile(Path.fromString(base) / "orWithFourRulesFailMetaData.csv"), parse(base + "/orWithFourRulesSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z].+") fails for line: 2, column: Country, value: "ngland"""",2,1))
+        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z].+") fails for line: 2, column: Country, value: "ngland"""",Some(2),Some(1)))
       }
     }
   }
@@ -325,7 +325,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if all the rules are not" in {
       validate(TextFile(Path.fromString(base) / "standardRulesFailMetaData.csv"), parse(base + "/standardRulesSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list.toString() mustEqual """List(ErrorMessage(uri fails for line: 1, column: uri, value: "http:##datagov.nationalarchives.gov.uk#66#WO#409#9999#0#aaaaaaaa-aaaa-4aaa-9eee-0123456789ab",1,0), ErrorMessage(xDateTime fails for line: 1, column: xDateTime, value: "2002-999-30T09:00:10",1,1), ErrorMessage(xDate fails for line: 1, column: xDate, value: "02-99-30",1,2), ErrorMessage(ukDate fails for line: 1, column: ukDate, value: "99/00/0009",1,3), ErrorMessage(xTime fails for line: 1, column: xTime, value: "99:00:889",1,4), ErrorMessage(uuid4 fails for line: 1, column: uuid4, value: "aaaaaaaab-aaaab-4aaa-9eee-0123456789ab",1,5), ErrorMessage(positiveInteger fails for line: 1, column: positiveInteger, value: "12-0912459",1,6))"""
+        case Failure(errors) => errors.list.toString() mustEqual """List(ErrorMessage(uri fails for line: 1, column: uri, value: "http:##datagov.nationalarchives.gov.uk#66#WO#409#9999#0#aaaaaaaa-aaaa-4aaa-9eee-0123456789ab",Some(1),Some(0)), ErrorMessage(xDateTime fails for line: 1, column: xDateTime, value: "2002-999-30T09:00:10",Some(1),Some(1)), ErrorMessage(xDate fails for line: 1, column: xDate, value: "02-99-30",Some(1),Some(2)), ErrorMessage(ukDate fails for line: 1, column: ukDate, value: "99/00/0009",Some(1),Some(3)), ErrorMessage(xTime fails for line: 1, column: xTime, value: "99:00:889",Some(1),Some(4)), ErrorMessage(uuid4 fails for line: 1, column: uuid4, value: "aaaaaaaab-aaaab-4aaa-9eee-0123456789ab",Some(1),Some(5)), ErrorMessage(positiveInteger fails for line: 1, column: positiveInteger, value: "12-0912459",Some(1),Some(6)))"""
 
       }
     }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorChecksumSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorChecksumSpec.scala
@@ -65,7 +65,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = s"$checksumPath,wrong"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + checksumPath + """"), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "wrong". Computed checksum value:"232762380299115da6995e4c4ac22fa2""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + checksumPath + """"), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "wrong". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",1,1))
       }
     }
   }
@@ -95,7 +95,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """ABC,wrong"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + schemaPath + """", "checksum.csvs"), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "wrong". Computed checksum value:"232762380299115da6995e4c4ac22fa2""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + schemaPath + """", "checksum.csvs"), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "wrong". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",1,1))
       }
     }
   }
@@ -126,7 +126,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """checksum.csvs,232762380299115da6995e4c4ac22fa2"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("invalid/path/to/root", $File), "MD5") incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("invalid/path/to/root", $File), "MD5") incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",1,1))
       }
     }
 
@@ -156,7 +156,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = s"$checksumPath,rubbish"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file($File), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "rubbish". Computed checksum value:"232762380299115da6995e4c4ac22fa2""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file($File), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "rubbish". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",1,1))
       }
     }
   }
@@ -172,7 +172,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """checksum.csvs,rubbish"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + schemaPath + """", $File), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "rubbish". Computed checksum value:"232762380299115da6995e4c4ac22fa2""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + schemaPath + """", $File), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "rubbish". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",1,1))
       }
     }
   }
@@ -205,7 +205,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """invalid/path/to/root,checksum.csvs,232762380299115da6995e4c4ac22fa2"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file($Root, $File), "MD5") incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file($Root, $File), "MD5") incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""", 1, 2))
       }
     }
   }
@@ -256,7 +256,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       validate(metaData, schema, None) must beLike {
         case Failure(messages) =>
           val msg = """checksum(file($Root, $File), "MD5") root """ + searchPath + FILE_SEPARATOR + """ (localfile: """ + searchPath + FILE_SEPARATOR + """checksum.*) should not contain wildcards for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2""""
-          messages.list mustEqual List(ErrorMessage(msg))
+          messages.list mustEqual List(ErrorMessage(msg, 1, 2))
       }
     }
 
@@ -272,7 +272,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """**/*.jp2,"232762380299115da6995e4c4ac22fa2""""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + threeFilesPath + """", $File), "MD5") multiple files for """ + threeFilesPath + s"""${FILE_SEPARATOR}**${FILE_SEPARATOR}*.jp2 found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + threeFilesPath + """", $File), "MD5") multiple files for """ + threeFilesPath + s"""${FILE_SEPARATOR}**${FILE_SEPARATOR}*.jp2 found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",1,1))
       }
     }
 
@@ -287,7 +287,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """**/*.jp2,"232762380299115da6995e4c4ac22fa2""""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("src/test/resources/this/is/incorrect", $File), "MD5") incorrect basepath src/test/resources/this/is/incorrect/ (localfile: """ + TypedPath("src/test/resources/this/is/incorrect/**/*.jp2").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("src/test/resources/this/is/incorrect", $File), "MD5") incorrect basepath src/test/resources/this/is/incorrect/ (localfile: """ + TypedPath("src/test/resources/this/is/incorrect/**/*.jp2").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",1,1))
       }
     }
   }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorChecksumSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorChecksumSpec.scala
@@ -65,7 +65,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = s"$checksumPath,wrong"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + checksumPath + """"), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "wrong". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + checksumPath + """"), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "wrong". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
       }
     }
   }
@@ -95,7 +95,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """ABC,wrong"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + schemaPath + """", "checksum.csvs"), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "wrong". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + schemaPath + """", "checksum.csvs"), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "wrong". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
       }
     }
   }
@@ -126,7 +126,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """checksum.csvs,232762380299115da6995e4c4ac22fa2"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("invalid/path/to/root", $File), "MD5") incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("invalid/path/to/root", $File), "MD5") incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
       }
     }
 
@@ -156,7 +156,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = s"$checksumPath,rubbish"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file($File), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "rubbish". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file($File), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "rubbish". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
       }
     }
   }
@@ -172,7 +172,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """checksum.csvs,rubbish"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + schemaPath + """", $File), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "rubbish". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + schemaPath + """", $File), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "rubbish". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
       }
     }
   }
@@ -205,7 +205,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """invalid/path/to/root,checksum.csvs,232762380299115da6995e4c4ac22fa2"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file($Root, $File), "MD5") incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""", 1, 2))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file($Root, $File), "MD5") incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""", Some(1), Some(2)))
       }
     }
   }
@@ -256,7 +256,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       validate(metaData, schema, None) must beLike {
         case Failure(messages) =>
           val msg = """checksum(file($Root, $File), "MD5") root """ + searchPath + FILE_SEPARATOR + """ (localfile: """ + searchPath + FILE_SEPARATOR + """checksum.*) should not contain wildcards for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2""""
-          messages.list mustEqual List(ErrorMessage(msg, 1, 2))
+          messages.list mustEqual List(ErrorMessage(msg, Some(1), Some(2)))
       }
     }
 
@@ -272,7 +272,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """**/*.jp2,"232762380299115da6995e4c4ac22fa2""""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + threeFilesPath + """", $File), "MD5") multiple files for """ + threeFilesPath + s"""${FILE_SEPARATOR}**${FILE_SEPARATOR}*.jp2 found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + threeFilesPath + """", $File), "MD5") multiple files for """ + threeFilesPath + s"""${FILE_SEPARATOR}**${FILE_SEPARATOR}*.jp2 found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
       }
     }
 
@@ -287,7 +287,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """**/*.jp2,"232762380299115da6995e4c4ac22fa2""""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("src/test/resources/this/is/incorrect", $File), "MD5") incorrect basepath src/test/resources/this/is/incorrect/ (localfile: """ + TypedPath("src/test/resources/this/is/incorrect/**/*.jp2").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("src/test/resources/this/is/incorrect", $File), "MD5") incorrect basepath src/test/resources/this/is/incorrect/ (localfile: """ + TypedPath("src/test/resources/this/is/incorrect/**/*.jp2").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
       }
     }
   }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorFileCountSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorFileCountSpec.scala
@@ -103,7 +103,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = s"$checksumPath,1"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + wrongPath + """")) file """" + wrongPath + """" not found for line: 1, column: Count, value: "1"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + wrongPath + """")) file """" + wrongPath + """" not found for line: 1, column: Count, value: "1"""",Some(1),Some(1)))
       }
     }
 
@@ -118,7 +118,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = s"$checksumPath,2"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + checksumPath + """")) found 1 file(s) for line: 1, column: Count, value: "2"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + checksumPath + """")) found 1 file(s) for line: 1, column: Count, value: "2"""",Some(1),Some(1)))
       }
     }
   }
@@ -149,7 +149,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = """ABC,99"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + schemaPath + """", "checksum.csvs")) found 1 file(s) for line: 1, column: Count, value: "99"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + schemaPath + """", "checksum.csvs")) found 1 file(s) for line: 1, column: Count, value: "99"""",Some(1),Some(1)))
       }
     }
   }
@@ -180,7 +180,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = """checksum.csvs,99"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("invalid/path/to/root", $File)) incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: Count, value: "99"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("invalid/path/to/root", $File)) incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: Count, value: "99"""",Some(1),Some(1)))
       }
     }
   }
@@ -212,7 +212,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = s"$checksumPath,rubbish"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file($File)) 'rubbish' is not a number for line: 1, column: Count, value: "rubbish"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file($File)) 'rubbish' is not a number for line: 1, column: Count, value: "rubbish"""",Some(1),Some(1)))
       }
     }
   }
@@ -246,7 +246,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = """invalid/path/to/root,checksum.csvs,99"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file($Root, $File)) incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: Count, value: "99"""",1,2))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file($Root, $File)) incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: Count, value: "99"""",Some(1),Some(2)))
       }
     }
   }
@@ -311,7 +311,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
 
       validate(metaData, schema, None) must beLike {
         case Failure(messages) =>
-          messages.list mustEqual List(ErrorMessage("""fileCount(file($Root, $File)) root """ + searchPath + """/ (localfile: """ + searchPath + FILE_SEPARATOR + """checksum.*) should not contain wildcards for line: 1, column: Count, value: "1"""",1,2))
+          messages.list mustEqual List(ErrorMessage("""fileCount(file($Root, $File)) root """ + searchPath + """/ (localfile: """ + searchPath + FILE_SEPARATOR + """checksum.*) should not contain wildcards for line: 1, column: Count, value: "1"""",Some(1),Some(2)))
       }
     }
 
@@ -339,7 +339,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = """**/*.jp2,2"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("src/test/resources/this/is/incorrect", $File)) incorrect basepath src/test/resources/this/is/incorrect/ (localfile: """ + TypedPath("src/test/resources/this/is/incorrect/**/*.jp2").toPlatform + """) found for line: 1, column: Count, value: "2"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("src/test/resources/this/is/incorrect", $File)) incorrect basepath src/test/resources/this/is/incorrect/ (localfile: """ + TypedPath("src/test/resources/this/is/incorrect/**/*.jp2").toPlatform + """) found for line: 1, column: Count, value: "2"""",Some(1),Some(1)))
       }
     }
   }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorFileCountSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorFileCountSpec.scala
@@ -103,7 +103,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = s"$checksumPath,1"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + wrongPath + """")) file """" + wrongPath + """" not found for line: 1, column: Count, value: "1""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + wrongPath + """")) file """" + wrongPath + """" not found for line: 1, column: Count, value: "1"""",1,1))
       }
     }
 
@@ -118,7 +118,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = s"$checksumPath,2"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + checksumPath + """")) found 1 file(s) for line: 1, column: Count, value: "2""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + checksumPath + """")) found 1 file(s) for line: 1, column: Count, value: "2"""",1,1))
       }
     }
   }
@@ -149,7 +149,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = """ABC,99"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + schemaPath + """", "checksum.csvs")) found 1 file(s) for line: 1, column: Count, value: "99""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + schemaPath + """", "checksum.csvs")) found 1 file(s) for line: 1, column: Count, value: "99"""",1,1))
       }
     }
   }
@@ -180,7 +180,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = """checksum.csvs,99"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("invalid/path/to/root", $File)) incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: Count, value: "99""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("invalid/path/to/root", $File)) incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: Count, value: "99"""",1,1))
       }
     }
   }
@@ -212,7 +212,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = s"$checksumPath,rubbish"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file($File)) 'rubbish' is not a number for line: 1, column: Count, value: "rubbish""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file($File)) 'rubbish' is not a number for line: 1, column: Count, value: "rubbish"""",1,1))
       }
     }
   }
@@ -246,7 +246,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = """invalid/path/to/root,checksum.csvs,99"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file($Root, $File)) incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: Count, value: "99""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file($Root, $File)) incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: Count, value: "99"""",1,2))
       }
     }
   }
@@ -311,7 +311,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
 
       validate(metaData, schema, None) must beLike {
         case Failure(messages) =>
-          messages.list mustEqual List(ErrorMessage("""fileCount(file($Root, $File)) root """ + searchPath + """/ (localfile: """ + searchPath + FILE_SEPARATOR + """checksum.*) should not contain wildcards for line: 1, column: Count, value: "1""""))
+          messages.list mustEqual List(ErrorMessage("""fileCount(file($Root, $File)) root """ + searchPath + """/ (localfile: """ + searchPath + FILE_SEPARATOR + """checksum.*) should not contain wildcards for line: 1, column: Count, value: "1"""",1,2))
       }
     }
 
@@ -339,7 +339,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = """**/*.jp2,2"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("src/test/resources/this/is/incorrect", $File)) incorrect basepath src/test/resources/this/is/incorrect/ (localfile: """ + TypedPath("src/test/resources/this/is/incorrect/**/*.jp2").toPlatform + """) found for line: 1, column: Count, value: "2""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("src/test/resources/this/is/incorrect", $File)) incorrect basepath src/test/resources/this/is/incorrect/ (localfile: """ + TypedPath("src/test/resources/this/is/incorrect/**/*.jp2").toPlatform + """) found for line: 1, column: Count, value: "2"""",1,1))
       }
     }
   }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorSpec.scala
@@ -74,7 +74,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("Expected @totalColumns of 3 and found 2 on line 2",2,2), ErrorMessage("Missing value at line: 2, column: column3",2,2))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("Expected @totalColumns of 3 and found 2 on line 2",2,-1), ErrorMessage("Missing value at line: 2, column: column3",2,2))
       }
     }
 
@@ -141,7 +141,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "1"
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("Expected @totalColumns of 2 and found 1 on line 1",1,1), ErrorMessage("Missing value at line: 1, column: Col2",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("Expected @totalColumns of 2 and found 1 on line 1",1,-1), ErrorMessage("Missing value at line: 1, column: Col2",1,1))
       }
     }
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorSpec.scala
@@ -74,7 +74,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("Expected @totalColumns of 3 and found 2 on line 2"), ErrorMessage("Missing value at line: 2, column: column3"))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("Expected @totalColumns of 3 and found 2 on line 2",2,2), ErrorMessage("Missing value at line: 2, column: column3",2,2))
       }
     }
 
@@ -93,9 +93,9 @@ class MetaDataValidatorSpec extends Specification with TestResources {
 
       validate(metaData, schema, None) must beLike {
         case Failure(messages) => messages.list mustEqual List (
-          ErrorMessage("""regex("[a-c]*") fails for line: 1, column: second, value: "xxxy""""),
-          ErrorMessage("""regex("[3-8]*") fails for line: 2, column: first, value: "abcd""""),
-          ErrorMessage("""regex("[a-c]*") fails for line: 2, column: second, value: "uii""""))
+          ErrorMessage("""regex("[a-c]*") fails for line: 1, column: second, value: "xxxy"""",1,1),
+          ErrorMessage("""regex("[3-8]*") fails for line: 2, column: first, value: "abcd"""",2,0),
+          ErrorMessage("""regex("[a-c]*") fails for line: 2, column: second, value: "uii"""",2,1))
       }
     }
 
@@ -126,7 +126,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "c11,c12"
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("C11") fails for line: 1, column: Col1, value: "c11""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("C11") fails for line: 1, column: Col1, value: "c11"""",1,0))
       }
     }
 
@@ -141,7 +141,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "1"
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("Expected @totalColumns of 2 and found 1 on line 1"), ErrorMessage("Missing value at line: 1, column: Col2"))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("Expected @totalColumns of 2 and found 1 on line 1",1,1), ErrorMessage("Missing value at line: 1, column: Col2",1,1))
       }
     }
 
@@ -167,7 +167,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = """Scooby"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("^T.+") fails for line: 1, column: c1, value: "Scooby""""), ErrorMessage("""regex("^X.+") fails for line: 1, column: c1, value: "Scooby""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("^T.+") fails for line: 1, column: c1, value: "Scooby"""",1,0), ErrorMessage("""regex("^X.+") fails for line: 1, column: c1, value: "Scooby"""",1,0))
       }
     }
 
@@ -214,7 +214,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
            blah_andMustBeIn,andMustBeIn"""
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in($col1) fails for line: 1, column: col2WithRule, value: "mustBeIn""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in($col1) fails for line: 1, column: col2WithRule, value: "mustBeIn"""",1,1))
       }
     }
 
@@ -259,7 +259,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "1,a,3"
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("[0-9]") fails for line: 1, column: Col2, value: "a""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("[0-9]") fails for line: 1, column: Col2, value: "a"""",1,1))
       }
     }
 
@@ -280,9 +280,9 @@ class MetaDataValidatorSpec extends Specification with TestResources {
 
       validate(metaData, schema, None) should beLike {
         case Failure(messages) => messages.list mustEqual List(
-          ErrorMessage("""regex("[0-9]") fails for line: 1, column: Col3, value: """""),
-          ErrorMessage("""regex("[0-9]") fails for line: 2, column: Col2, value: "a""""),
-          ErrorMessage("""regex("[0-9]") fails for line: 2, column: Col3, value: """""))
+          ErrorMessage("""regex("[0-9]") fails for line: 1, column: Col3, value: """"",1,2),
+          ErrorMessage("""regex("[0-9]") fails for line: 2, column: Col2, value: "a"""",2,1),
+          ErrorMessage("""regex("[0-9]") fails for line: 2, column: Col3, value: """"",2,2))
       }
     }
 
@@ -320,7 +320,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "SCOOBY"
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("[a-z]+") fails for line: 1, column: Col1, value: "SCOOBY""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("[a-z]+") fails for line: 1, column: Col1, value: "SCOOBY"""",1,0))
       }
     }
 
@@ -362,7 +362,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "some/non/existent/file"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("fileExists fails for line: 1, column: FirstColumn, value: \"some/non/existent/file\""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("fileExists fails for line: 1, column: FirstColumn, value: \"some/non/existent/file\"",1,0))
       }
     }
 
@@ -380,7 +380,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in("dog") fails for line: 1, column: col2WithRule, value: "thisisrubbish""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in("dog") fails for line: 1, column: col2WithRule, value: "thisisrubbish"""",1,1))
       }
     }
 
@@ -398,7 +398,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in("dog") fails for line: 1, column: col2WithRule, value: "thisisrubbish""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in("dog") fails for line: 1, column: col2WithRule, value: "thisisrubbish"""",1,1))
       }
     }
 
@@ -413,7 +413,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = ""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file is empty but this has not been permitted"))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file is empty but this has not been permitted",0,0))
       }
     }
 
@@ -442,7 +442,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = ""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file is empty but should contain at least a header"))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file is empty but should contain at least a header",0,0))
       }
     }
 
@@ -469,7 +469,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "Name"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file has a header but no data and this has not been permitted"))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file has a header but no data and this has not been permitted",0,0))
       }
     }
 
@@ -498,7 +498,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "SomethingElse"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in("This") or in("That") fails for line: 1, column: ThisOrThat, value: "SomethingElse""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in("This") or in("That") fails for line: 1, column: ThisOrThat, value: "SomethingElse"""",1,0))
       }
     }
 
@@ -564,7 +564,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "UK"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""is("France") fails for line: 1, column: Country, value: "UK""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""is("France") fails for line: 1, column: Country, value: "UK"""",1,0))
       }
     }
 
@@ -579,7 +579,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United,United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""is($MyCountry) fails for line: 1, column: Country, value: "United""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""is($MyCountry) fails for line: 1, column: Country, value: "United"""",1,0))
       }
     }
 
@@ -630,7 +630,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""not("United Kingdom") fails for line: 1, column: Country, value: "United Kingdom""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""not("United Kingdom") fails for line: 1, column: Country, value: "United Kingdom"""",1,0))
       }
     }
 
@@ -645,7 +645,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom,United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""not($MyCountry) fails for line: 1, column: Country, value: "United Kingdom""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""not($MyCountry) fails for line: 1, column: Country, value: "United Kingdom"""",1,0))
       }
     }
 
@@ -696,7 +696,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""starts("united") fails for line: 1, column: Country, value: "United Kingdom""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""starts("united") fails for line: 1, column: Country, value: "United Kingdom"""",1,0))
       }
     }
 
@@ -711,7 +711,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United,United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""starts($MyCountry) fails for line: 1, column: Country, value: "United""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""starts($MyCountry) fails for line: 1, column: Country, value: "United"""",1,0))
       }
     }
 
@@ -761,7 +761,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("kingdom") fails for line: 1, column: Country, value: "United Kingdom""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("kingdom") fails for line: 1, column: Country, value: "United Kingdom"""",1,0))
       }
     }
 
@@ -776,7 +776,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom,States"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends($MyCountry) fails for line: 1, column: Country, value: "United Kingdom""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends($MyCountry) fails for line: 1, column: Country, value: "United Kingdom"""",1,0))
       }
     }
 
@@ -814,7 +814,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("unique fails for line: 4, column: Name, value: \"Jim\" (original at line: 2)"),ErrorMessage("unique fails for line: 5, column: Name, value: \"Jim\" (original at line: 2)"))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("unique fails for line: 4, column: Name, value: \"Jim\" (original at line: 2)",4,0),ErrorMessage("unique fails for line: 5, column: Name, value: \"Jim\" (original at line: 2)",5,0))
       }
     }
 
@@ -1013,7 +1013,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("range(18,65) fails for line: 1, column: Age, value: \"10\""),ErrorMessage("range(18,65) fails for line: 3, column: Age, value: \"96\""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("range(18,65) fails for line: 1, column: Age, value: \"10\"",1,1),ErrorMessage("range(18,65) fails for line: 3, column: Age, value: \"96\"",3,1))
       }
     }
 
@@ -1031,7 +1031,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("length(*,3) fails for line: 3, column: Name, value: \"Benny\""),ErrorMessage("length(*,3) fails for line: 5, column: Name, value: \"Timmy\""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("length(*,3) fails for line: 3, column: Name, value: \"Benny\"",3,0),ErrorMessage("length(*,3) fails for line: 5, column: Name, value: \"Timmy\"",5,0))
       }
     }
 
@@ -1060,7 +1060,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""(length(5) and length(*,*)) and is("Hello") fails for line: 2, column: Name, value: "World""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""(length(5) and length(*,*)) and is("Hello") fails for line: 2, column: Name, value: "World"""",2,0))
       }
     }
 
@@ -1138,7 +1138,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
       val metaData ="Joe Bloggs"
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("Joe") fails for line: 1, column: col1, value: "Joe Bloggs""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("Joe") fails for line: 1, column: col1, value: "Joe Bloggs"""",1,0))
       }
     }
 
@@ -1160,7 +1160,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
       val metaData ="Joe Bloggs"
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("Joe") fails for line: 1, column: col1, value: "Joe Bloggs""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("Joe") fails for line: 1, column: col1, value: "Joe Bloggs"""",1,0))
       }
     }
 
@@ -1192,7 +1192,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
       val metaData ="Joe Bloggs"
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""length(4) fails for line: 1, column: col1, value: "Joe Bloggs""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""length(4) fails for line: 1, column: col1, value: "Joe Bloggs"""",1,0))
       }
     }
 
@@ -1235,7 +1235,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
       val metaData ="True"
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""(is("True") or is("True")) and is("False") fails for line: 1, column: col1, value: "True""""))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""(is("True") or is("True")) and is("False") fails for line: 1, column: col1, value: "True"""",1,0))
       }
     }
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorSpec.scala
@@ -74,7 +74,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("Expected @totalColumns of 3 and found 2 on line 2",2,-1), ErrorMessage("Missing value at line: 2, column: column3",2,2))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("Expected @totalColumns of 3 and found 2 on line 2",Some(2)), ErrorMessage("Missing value at line: 2, column: column3",Some(2),Some(2)))
       }
     }
 
@@ -93,9 +93,9 @@ class MetaDataValidatorSpec extends Specification with TestResources {
 
       validate(metaData, schema, None) must beLike {
         case Failure(messages) => messages.list mustEqual List (
-          ErrorMessage("""regex("[a-c]*") fails for line: 1, column: second, value: "xxxy"""",1,1),
-          ErrorMessage("""regex("[3-8]*") fails for line: 2, column: first, value: "abcd"""",2,0),
-          ErrorMessage("""regex("[a-c]*") fails for line: 2, column: second, value: "uii"""",2,1))
+          ErrorMessage("""regex("[a-c]*") fails for line: 1, column: second, value: "xxxy"""",Some(1),Some(1)),
+          ErrorMessage("""regex("[3-8]*") fails for line: 2, column: first, value: "abcd"""",Some(2),Some(0)),
+          ErrorMessage("""regex("[a-c]*") fails for line: 2, column: second, value: "uii"""",Some(2),Some(1)))
       }
     }
 
@@ -126,7 +126,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "c11,c12"
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("C11") fails for line: 1, column: Col1, value: "c11"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("C11") fails for line: 1, column: Col1, value: "c11"""",Some(1),Some(0)))
       }
     }
 
@@ -141,7 +141,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "1"
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("Expected @totalColumns of 2 and found 1 on line 1",1,-1), ErrorMessage("Missing value at line: 1, column: Col2",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("Expected @totalColumns of 2 and found 1 on line 1",Some(1)), ErrorMessage("Missing value at line: 1, column: Col2",Some(1),Some(1)))
       }
     }
 
@@ -167,7 +167,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = """Scooby"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("^T.+") fails for line: 1, column: c1, value: "Scooby"""",1,0), ErrorMessage("""regex("^X.+") fails for line: 1, column: c1, value: "Scooby"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("^T.+") fails for line: 1, column: c1, value: "Scooby"""",Some(1),Some(0)), ErrorMessage("""regex("^X.+") fails for line: 1, column: c1, value: "Scooby"""",Some(1),Some(0)))
       }
     }
 
@@ -214,7 +214,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
            blah_andMustBeIn,andMustBeIn"""
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in($col1) fails for line: 1, column: col2WithRule, value: "mustBeIn"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in($col1) fails for line: 1, column: col2WithRule, value: "mustBeIn"""",Some(1),Some(1)))
       }
     }
 
@@ -259,7 +259,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "1,a,3"
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("[0-9]") fails for line: 1, column: Col2, value: "a"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("[0-9]") fails for line: 1, column: Col2, value: "a"""",Some(1),Some(1)))
       }
     }
 
@@ -280,9 +280,9 @@ class MetaDataValidatorSpec extends Specification with TestResources {
 
       validate(metaData, schema, None) should beLike {
         case Failure(messages) => messages.list mustEqual List(
-          ErrorMessage("""regex("[0-9]") fails for line: 1, column: Col3, value: """"",1,2),
-          ErrorMessage("""regex("[0-9]") fails for line: 2, column: Col2, value: "a"""",2,1),
-          ErrorMessage("""regex("[0-9]") fails for line: 2, column: Col3, value: """"",2,2))
+          ErrorMessage("""regex("[0-9]") fails for line: 1, column: Col3, value: """"",Some(1),Some(2)),
+          ErrorMessage("""regex("[0-9]") fails for line: 2, column: Col2, value: "a"""",Some(2),Some(1)),
+          ErrorMessage("""regex("[0-9]") fails for line: 2, column: Col3, value: """"",Some(2),Some(2)))
       }
     }
 
@@ -320,7 +320,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "SCOOBY"
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("[a-z]+") fails for line: 1, column: Col1, value: "SCOOBY"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("[a-z]+") fails for line: 1, column: Col1, value: "SCOOBY"""",Some(1),Some(0)))
       }
     }
 
@@ -362,7 +362,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "some/non/existent/file"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("fileExists fails for line: 1, column: FirstColumn, value: \"some/non/existent/file\"",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("fileExists fails for line: 1, column: FirstColumn, value: \"some/non/existent/file\"",Some(1),Some(0)))
       }
     }
 
@@ -380,7 +380,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in("dog") fails for line: 1, column: col2WithRule, value: "thisisrubbish"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in("dog") fails for line: 1, column: col2WithRule, value: "thisisrubbish"""",Some(1),Some(1)))
       }
     }
 
@@ -398,7 +398,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in("dog") fails for line: 1, column: col2WithRule, value: "thisisrubbish"""",1,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in("dog") fails for line: 1, column: col2WithRule, value: "thisisrubbish"""",Some(1),Some(1)))
       }
     }
 
@@ -413,7 +413,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = ""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file is empty but this has not been permitted",0,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file is empty but this has not been permitted"))
       }
     }
 
@@ -442,7 +442,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = ""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file is empty but should contain at least a header",0,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file is empty but should contain at least a header"))
       }
     }
 
@@ -469,7 +469,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "Name"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file has a header but no data and this has not been permitted",0,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file has a header but no data and this has not been permitted"))
       }
     }
 
@@ -498,7 +498,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "SomethingElse"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in("This") or in("That") fails for line: 1, column: ThisOrThat, value: "SomethingElse"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in("This") or in("That") fails for line: 1, column: ThisOrThat, value: "SomethingElse"""",Some(1),Some(0)))
       }
     }
 
@@ -564,7 +564,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "UK"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""is("France") fails for line: 1, column: Country, value: "UK"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""is("France") fails for line: 1, column: Country, value: "UK"""",Some(1),Some(0)))
       }
     }
 
@@ -579,7 +579,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United,United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""is($MyCountry) fails for line: 1, column: Country, value: "United"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""is($MyCountry) fails for line: 1, column: Country, value: "United"""",Some(1),Some(0)))
       }
     }
 
@@ -630,7 +630,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""not("United Kingdom") fails for line: 1, column: Country, value: "United Kingdom"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""not("United Kingdom") fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
       }
     }
 
@@ -645,7 +645,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom,United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""not($MyCountry) fails for line: 1, column: Country, value: "United Kingdom"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""not($MyCountry) fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
       }
     }
 
@@ -696,7 +696,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""starts("united") fails for line: 1, column: Country, value: "United Kingdom"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""starts("united") fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
       }
     }
 
@@ -711,7 +711,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United,United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""starts($MyCountry) fails for line: 1, column: Country, value: "United"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""starts($MyCountry) fails for line: 1, column: Country, value: "United"""",Some(1),Some(0)))
       }
     }
 
@@ -761,7 +761,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("kingdom") fails for line: 1, column: Country, value: "United Kingdom"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("kingdom") fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
       }
     }
 
@@ -776,7 +776,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom,States"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends($MyCountry) fails for line: 1, column: Country, value: "United Kingdom"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends($MyCountry) fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
       }
     }
 
@@ -814,7 +814,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("unique fails for line: 4, column: Name, value: \"Jim\" (original at line: 2)",4,0),ErrorMessage("unique fails for line: 5, column: Name, value: \"Jim\" (original at line: 2)",5,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("unique fails for line: 4, column: Name, value: \"Jim\" (original at line: 2)",Some(4),Some(0)),ErrorMessage("unique fails for line: 5, column: Name, value: \"Jim\" (original at line: 2)",Some(5),Some(0)))
       }
     }
 
@@ -1013,7 +1013,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("range(18,65) fails for line: 1, column: Age, value: \"10\"",1,1),ErrorMessage("range(18,65) fails for line: 3, column: Age, value: \"96\"",3,1))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("range(18,65) fails for line: 1, column: Age, value: \"10\"",Some(1),Some(1)),ErrorMessage("range(18,65) fails for line: 3, column: Age, value: \"96\"",Some(3),Some(1)))
       }
     }
 
@@ -1031,7 +1031,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("length(*,3) fails for line: 3, column: Name, value: \"Benny\"",3,0),ErrorMessage("length(*,3) fails for line: 5, column: Name, value: \"Timmy\"",5,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("length(*,3) fails for line: 3, column: Name, value: \"Benny\"",Some(3),Some(0)),ErrorMessage("length(*,3) fails for line: 5, column: Name, value: \"Timmy\"",Some(5),Some(0)))
       }
     }
 
@@ -1060,7 +1060,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""(length(5) and length(*,*)) and is("Hello") fails for line: 2, column: Name, value: "World"""",2,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""(length(5) and length(*,*)) and is("Hello") fails for line: 2, column: Name, value: "World"""",Some(2),Some(0)))
       }
     }
 
@@ -1138,7 +1138,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
       val metaData ="Joe Bloggs"
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("Joe") fails for line: 1, column: col1, value: "Joe Bloggs"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("Joe") fails for line: 1, column: col1, value: "Joe Bloggs"""",Some(1),Some(0)))
       }
     }
 
@@ -1160,7 +1160,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
       val metaData ="Joe Bloggs"
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("Joe") fails for line: 1, column: col1, value: "Joe Bloggs"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("Joe") fails for line: 1, column: col1, value: "Joe Bloggs"""",Some(1),Some(0)))
       }
     }
 
@@ -1192,7 +1192,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
       val metaData ="Joe Bloggs"
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""length(4) fails for line: 1, column: col1, value: "Joe Bloggs"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""length(4) fails for line: 1, column: col1, value: "Joe Bloggs"""",Some(1),Some(0)))
       }
     }
 
@@ -1235,7 +1235,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
       val metaData ="True"
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""(is("True") or is("True")) and is("False") fails for line: 1, column: col1, value: "True"""",1,0))
+        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""(is("True") or is("True")) and is("False") fails for line: 1, column: col1, value: "True"""",Some(1),Some(0)))
       }
     }
 

--- a/csv-validator-java-api/src/main/java/uk/gov/nationalarchives/csv/validator/api/java/ErrorMessage.java
+++ b/csv-validator-java-api/src/main/java/uk/gov/nationalarchives/csv/validator/api/java/ErrorMessage.java
@@ -13,7 +13,7 @@ package uk.gov.nationalarchives.csv.validator.api.java;
  */
 public class ErrorMessage extends FailMessage {
 
-    public ErrorMessage(final String message) {
-        super(message);
+    public ErrorMessage(final String message, final int lineNumber, final int columnIndex) {
+        super(message, lineNumber, columnIndex);
     }
 }

--- a/csv-validator-java-api/src/main/java/uk/gov/nationalarchives/csv/validator/api/java/FailMessage.java
+++ b/csv-validator-java-api/src/main/java/uk/gov/nationalarchives/csv/validator/api/java/FailMessage.java
@@ -13,15 +13,31 @@ package uk.gov.nationalarchives.csv.validator.api.java;
  */
 public abstract class FailMessage {
     private final String message;
+    private final int lineNumber;
+    private final int columnIndex;
 
     /**
      * @param message The failure message
+     * @param lineNumber The original line number in the file
+     * @param columnIndex Zero-based column index
      */
-    public FailMessage(final String message) {
+    public FailMessage(final String message, final int lineNumber, final int columnIndex) {
         this.message = message;
+        this.lineNumber = lineNumber;
+        this.columnIndex = columnIndex;
     }
 
     public String getMessage() {
         return message;
+    }
+
+    public int getLineNumber()
+    {
+        return lineNumber;
+    }
+
+    public int getColumnIndex()
+    {
+        return columnIndex;
     }
 }

--- a/csv-validator-java-api/src/main/java/uk/gov/nationalarchives/csv/validator/api/java/WarningMessage.java
+++ b/csv-validator-java-api/src/main/java/uk/gov/nationalarchives/csv/validator/api/java/WarningMessage.java
@@ -13,7 +13,7 @@ package uk.gov.nationalarchives.csv.validator.api.java;
  */
 public class WarningMessage extends FailMessage {
 
-    public WarningMessage(final String message) {
-        super(message);
+    public WarningMessage(final String message, final int lineNumber, final int columnIndex) {
+        super(message, lineNumber, columnIndex);
     }
 }

--- a/csv-validator-java-api/src/main/scala/uk/gov/nationalarchives/csv/validator/api/java/CsvValidatorJavaBridge.scala
+++ b/csv-validator-java-api/src/main/scala/uk/gov/nationalarchives/csv/validator/api/java/CsvValidatorJavaBridge.scala
@@ -95,8 +95,8 @@ object CsvValidatorJavaBridge {
   }
 
   private def asJavaMessage(f: SFailMessage): FailMessage = f match {
-    case SWarningMessage(msg, lineNr, columnIdx) => new WarningMessage(msg, lineNr, columnIdx).asInstanceOf[FailMessage]
-    case SErrorMessage(msg, lineNr, columnIdx) => new ErrorMessage(msg, lineNr, columnIdx).asInstanceOf[FailMessage]
-    case SSchemaMessage(msg, lineNr, columnIdx) => new ErrorMessage(msg, lineNr, columnIdx).asInstanceOf[FailMessage]
+    case SWarningMessage(msg, lineNr, columnIdx) => new WarningMessage(msg, lineNr.getOrElse(-1), columnIdx.getOrElse(-1)).asInstanceOf[FailMessage]
+    case SErrorMessage(msg, lineNr, columnIdx) => new ErrorMessage(msg, lineNr.getOrElse(-1), columnIdx.getOrElse(-1)).asInstanceOf[FailMessage]
+    case SSchemaMessage(msg, lineNr, columnIdx) => new ErrorMessage(msg, lineNr.getOrElse(-1), columnIdx.getOrElse(-1)).asInstanceOf[FailMessage]
   }
 }

--- a/csv-validator-java-api/src/main/scala/uk/gov/nationalarchives/csv/validator/api/java/CsvValidatorJavaBridge.scala
+++ b/csv-validator-java-api/src/main/scala/uk/gov/nationalarchives/csv/validator/api/java/CsvValidatorJavaBridge.scala
@@ -95,8 +95,8 @@ object CsvValidatorJavaBridge {
   }
 
   private def asJavaMessage(f: SFailMessage): FailMessage = f match {
-    case SWarningMessage(msg) => new WarningMessage(msg).asInstanceOf[FailMessage]
-    case SErrorMessage(msg) => new ErrorMessage(msg).asInstanceOf[FailMessage]
-    case SSchemaMessage(msg) => new ErrorMessage(msg).asInstanceOf[FailMessage]
+    case SWarningMessage(msg, lineNr, columnIdx) => new WarningMessage(msg, lineNr, columnIdx).asInstanceOf[FailMessage]
+    case SErrorMessage(msg, lineNr, columnIdx) => new ErrorMessage(msg, lineNr, columnIdx).asInstanceOf[FailMessage]
+    case SSchemaMessage(msg, lineNr, columnIdx) => new ErrorMessage(msg, lineNr, columnIdx).asInstanceOf[FailMessage]
   }
 }


### PR DESCRIPTION
In our project we need an explicit line number and column index in the Error Message as opposed to the reference inside the message string. Maybe it could be of value to others as well.