### PR TITLE
Implemented feature unbound range rule

### DIFF
--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/Rule.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/Rule.scala
@@ -640,16 +640,19 @@ trait FileWildcardSearch[T] {
   }
 }
 
-case class RangeRule(min: BigDecimal, max: BigDecimal) extends Rule("range") {
+case class RangeRule(min: Option[BigDecimal], max: Option[BigDecimal]) extends Rule("range") {
+
   def valid(cellValue: String, columnDefinition: ColumnDefinition, columnIndex: Int, row: Row, schema: Schema): Boolean = {
 
     Try[BigDecimal]( BigDecimal(cellValue)) match {
-      case scala.util.Success(callDecimal) => if (callDecimal >= min && callDecimal <= max  ) true  else false
+      
+      case scala.util.Success(callDecimal) =>
+        min.map( callDecimal >= _).getOrElse(true) &&  max.map( callDecimal <= _).getOrElse(true)
       case _ => false
      }
   }
 
-  override def toError = s"""$ruleName($min,$max)"""
+  override def toError = s"""$ruleName(${min.getOrElse("*")},${max.getOrElse("*")})"""
 }
 
 case class LengthRule(from: Option[String], to: String) extends Rule("length") {

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaParser.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaParser.scala
@@ -339,11 +339,10 @@ trait SchemaParser extends RegexParsers
   } withFailureMessage("""regex not correctly delimited as ("your regex")""")
 
   /**
-   * [43] RangeExpr ::= "range(" NumericLiteral "," NumericLiteral ")" /* range is inclusive */
+   * [43] RangeExpr ::= "range(" NumericOrAny "," NumericOrAny ")" /* range is inclusive */
    */
-  lazy val rangeExpr: PackratParser[RangeRule] = "RangeExpr" ::= "range(" ~> numericLiteral ~ "," ~ numericLiteral <~ ")"  ^^ {
-    case a ~ "," ~ b =>
-      RangeRule(a, b)
+  lazy val rangeExpr: PackratParser[RangeRule] = "RangeExpr" ::= "range(" ~> numericOrAny ~ "," ~ numericOrAny <~ ")"  ^^ {
+    case a ~ "," ~ b => RangeRule(a,b)
   }
 
   /**
@@ -368,6 +367,16 @@ trait SchemaParser extends RegexParsers
    */
   def positiveIntegerOrAny: Parser[Option[BigInt]] = "PositiveIntegerOrAny" ::= (positiveIntegerLiteral | wildcardLiteral) ^^ {
     case positiveInteger: BigInt =>
+      Option(positiveInteger)
+    case wildcard =>
+      Option.empty
+  }
+
+  /**
+   * [45] PositiveIntegerOrAny ::=  PositiveIntegerLiteral | WildcardLiteral
+   */
+  def numericOrAny: Parser[Option[BigDecimal]] = "NumericOrAny" ::= (numericLiteral | wildcardLiteral) ^^ {
+    case positiveInteger: BigDecimal =>
       Option(positiveInteger)
     case wildcard =>
       Option.empty
@@ -792,21 +801,26 @@ trait SchemaParser extends RegexParsers
   }
 
   private def rangeValid(columnDefinitions: List[ColumnDefinition]): Option[String] = {
-    def rangeCheck(rule: Rule): Boolean = rule match {
-      case RangeRule(min,max) => min > max
-      case _ => false
+    def rangeCheck(rule: Rule): Option[String] = rule match {
+      case RangeRule(None,None) =>  Some(s"""Invalid range in 'range(*,*)' at least one value needs to be defined""")
+      case RangeRule(Some(min),Some(max)) => if (min > max) Some(s"""Invalid range, minimum greater than maximum in: 'range($min,$max)' at line: ${rule.pos.line}, column: ${rule.pos.column}""") else None
+      case _ => None
     }
 
     val v = for {
       cd <- columnDefinitions
       rule <- cd.rules
-      if (rangeCheck(rule))
+      message = rangeCheck(rule)
+      if (message.isDefined)
     } yield {
-      rule match {
-        case range:RangeRule => s"""Column: ${cd.id}: Invalid range, minimum greater than maximum in: 'range(${range.min},${range.max})' at line: ${rule.pos.line}, column: ${rule.pos.column}"""
+      val errormessage = rule match {
+        case range:RangeRule => message.getOrElse("")
         case _ =>  s"""Column: ${cd.id}: Invalid range, minimum greater than maximum: at line: ${rule.pos.line}, column: ${rule.pos.column}"""
       }
+      s"""Column: ${cd.id}: """ + errormessage
+
     }
+
 
     if (v.isEmpty) None else Some(v.mkString(EOL))
   }

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaParser.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaParser.scala
@@ -373,7 +373,7 @@ trait SchemaParser extends RegexParsers
   }
 
   /**
-   * [45] PositiveIntegerOrAny ::=  PositiveIntegerLiteral | WildcardLiteral
+   * [45.1] NumericOrAny ::=  NumericLiteral | WildcardLiteral
    */
   def numericOrAny: Parser[Option[BigDecimal]] = "NumericOrAny" ::= (numericLiteral | wildcardLiteral) ^^ {
     case positiveInteger: BigDecimal =>

--- a/csv-validator-core/src/test/resources/uk/gov/nationalarchives/csv/validator/acceptance/rangeRuleFailMetaData.csv
+++ b/csv-validator-core/src/test/resources/uk/gov/nationalarchives/csv/validator/acceptance/rangeRuleFailMetaData.csv
@@ -1,0 +1,3 @@
+Name,Year_of_birth
+Andy,1985
+Ben,1909

--- a/csv-validator-core/src/test/resources/uk/gov/nationalarchives/csv/validator/acceptance/rangeRuleFailSchema.csvs
+++ b/csv-validator-core/src/test/resources/uk/gov/nationalarchives/csv/validator/acceptance/rangeRuleFailSchema.csvs
@@ -1,0 +1,4 @@
+version 1.0
+@totalColumns 2
+Name:
+Year_of_birth: range(*,*)

--- a/csv-validator-core/src/test/resources/uk/gov/nationalarchives/csv/validator/acceptance/rangeRuleInvalidSchema.csvs
+++ b/csv-validator-core/src/test/resources/uk/gov/nationalarchives/csv/validator/acceptance/rangeRuleInvalidSchema.csvs
@@ -1,0 +1,4 @@
+version 1.0
+@totalColumns 2
+Name:
+Year_of_birth: range(100,1)

--- a/csv-validator-core/src/test/resources/uk/gov/nationalarchives/csv/validator/acceptance/rangeRulePassMetaData.csv
+++ b/csv-validator-core/src/test/resources/uk/gov/nationalarchives/csv/validator/acceptance/rangeRulePassMetaData.csv
@@ -1,0 +1,3 @@
+Name,Year_of_birth
+Andy,1985
+Ben,1970

--- a/csv-validator-core/src/test/resources/uk/gov/nationalarchives/csv/validator/acceptance/rangeRuleSchema.csvs
+++ b/csv-validator-core/src/test/resources/uk/gov/nationalarchives/csv/validator/acceptance/rangeRuleSchema.csvs
@@ -1,0 +1,4 @@
+version 1.0
+@totalColumns 2
+Name:
+Year_of_birth: range(1910,*)

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
@@ -225,6 +225,36 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     }
   }
 
+  "A range rule" should {
+
+    "enforce all element in a call on to be in a range of value" in {
+      validate(TextFile(Path.fromString(base) / "rangeRulePassMetaData.csv"), parse(base + "/rangeRuleSchema.csvs"), None).isSuccess mustEqual  true
+    }
+
+    "enforce all element in a call on to be in a range of value" in {
+      validate(TextFile(Path.fromString(base) / "rangeRuleFailMetaData.csv"), parse(base + "/rangeRuleSchema.csvs"), None) must beLike {
+        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""range(1910,*) fails for line: 2, column: Year_of_birth, value: "1909"""",Some(2),Some(1)))
+      }
+    }
+
+    "fail with no limit set" in {
+      parseSchema(TextFile(Path.fromString(base) / "rangeRuleFailSchema.csvs")) must beLike {
+          case Failure(errors) => errors.list mustEqual List(SchemaMessage("""Column: Year_of_birth: Invalid range in 'range(*,*)' at least one value needs to be defined""",None,None))
+        }
+      }
+
+
+    "fail with inconsistent limit" in {
+      parseSchema(TextFile(Path.fromString(base) / "rangeRuleInvalidSchema.csvs")) must beLike {
+        case Failure(errors) => errors.list mustEqual List(SchemaMessage("""Column: Year_of_birth: Invalid range, minimum greater than maximum in: 'range(100,1)' at line: 4, column: 16""",None,None))
+      }
+    }
+
+
+
+  }
+
+
   "A checksum rule" should {
 
     "enforce case-sensitive comparisons when case-sensitive comparisons are set" in {
@@ -262,6 +292,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
         case Success(_) => ok
       }
     }
+
 
     "report warnings" in {
       app.validate(TextFile(Path.fromString(base) / "warnings.csv"), parse(base + "/warnings.csvs"), None) must beLike {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/UtilSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/UtilSpec.scala
@@ -30,7 +30,7 @@ class UtilSpec  extends Specification with TestResources  {
 
       val apiFiles = Util.findAllFiles(true, new File(acceptancePath))
 
-      apiFiles must haveLength(70)
+      apiFiles must haveLength(75)
 
       apiFiles must contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/acceptance/twoRulesPassMetaData.csv"))
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/RangeRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/RangeRuleSpec.scala
@@ -20,7 +20,7 @@ class RangeRuleSpec extends Specification {
     val schema = Schema(globalDirectives, List(ColumnDefinition(NamedColumnIdentifier("Country"))))
 
     "fail when non numeric number passed" in {
-      val rangeRule = new RangeRule(1,2)
+      val rangeRule = new RangeRule(Some(1),Some(2))
 
       rangeRule.evaluate(0, Row(List(Cell("Germany")), 1), schema) must beLike {
         case Failure(messages) => messages.list mustEqual List("""range(1,2) fails for line: 1, column: Country, value: "Germany"""")
@@ -28,13 +28,25 @@ class RangeRuleSpec extends Specification {
     }
 
     "pass when we test integer boundaries" in {
-      val rangeRule = new RangeRule(Int.MinValue,(Int.MaxValue))
+      val rangeRule = new RangeRule(Some(Int.MinValue),Some(Int.MaxValue))
 
       rangeRule.evaluate(0, Row(List(Cell((Int.MaxValue).toString)), 1), schema)  mustEqual Success(true)
     }
 
+    "pass when we test integer boundaries with no max limit" in {
+      val rangeRule = new RangeRule(Some(0) ,None)
+
+      rangeRule.evaluate(0, Row(List(Cell(BigDecimal(Int.MaxValue).toString)), 1), schema)  mustEqual Success(true)
+    }
+
+    "pass when we test integer boundaries with no min limit" in {
+      val rangeRule = new RangeRule(None,Some(0) )
+
+      rangeRule.evaluate(0, Row(List(Cell(BigDecimal(Int.MinValue).toString)), 1), schema)  mustEqual Success(true)
+    }
+
     "fail when we test small decimal outside range" in {
-      val rangeRule = new RangeRule(0.01,0.1)
+      val rangeRule = new RangeRule(Some(0.01),Some(0.1))
 
       rangeRule.evaluate(0, Row(List(Cell(("0.00999999999999999999999999999999"))), 1), schema)  must beLike {
         case Failure(messages) => messages.list mustEqual List("""range(0.01,0.1) fails for line: 1, column: Country, value: "0.00999999999999999999999999999999"""")


### PR DESCRIPTION
Define unbound range, so that now range(&#42;,10) or range(5,&#42;) can be define. None though at least one of the limit has to be set, a range(&#42;,&#42;) would cause schema validation failure.