### PR TITLE
Fix a dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Validation tool and APIs are written in Scala 2.11 and may be used as:
 * A library in your Java project (We provide a Java 7 interface, to make things simple for Java programmers too).
 
 The Validation Tool and APIs can be used on any Java Virtual Machine which supports Java 7 or better (**NB Java 6 support was removed in version 1.1**). The source code is
-built using the [Apache Maven](http://apache.maven.org) build tool, by executing `mvn clean install`.
+built using the [Apache Maven](https://maven.apache.org/) build tool, by executing `mvn clean install`.
 
 
 Maven Artifacts


### PR DESCRIPTION
I have found that a link http://apache.maven.org/ is already dead.