### PR TITLE
Update the version of Scalaz and associated libraries

### DIFF
--- a/csv-validator-cmd/pom.xml
+++ b/csv-validator-cmd/pom.xml
@@ -31,6 +31,8 @@
                     <useZincServer>true</useZincServer>          <!-- NOTE: if you have Zinc server installed and running, you can get faster compilation by enabling this -->
                     <args>
                         <arg>-Yrangepos</arg> <!-- recommended for Specs2 -->
+                        <arg>-feature</arg>
+                        <arg>-deprecation</arg>
                     </args>
                     <javacArgs>
                         <javacArg>-Xlint:unchecked</javacArg>

--- a/csv-validator-cmd/pom.xml
+++ b/csv-validator-cmd/pom.xml
@@ -29,6 +29,9 @@
                 <configuration>
                     <recompileMode>incremental</recompileMode>   <!-- NOTE: incremental compilation although faster requires passing to MAVEN_OPTS="-XX:MaxPermSize=128m" -->
                     <useZincServer>true</useZincServer>          <!-- NOTE: if you have Zinc server installed and running, you can get faster compilation by enabling this -->
+                    <args>
+                        <arg>-Yrangepos</arg> <!-- recommended for Specs2 -->
+                    </args>
                     <javacArgs>
                         <javacArg>-Xlint:unchecked</javacArg>
                         <javacArg>-Xlint:deprecation</javacArg>
@@ -52,17 +55,13 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.mmakowski</groupId>
-                <artifactId>maven-specs2-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>verify</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>run-specs</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*Spec.*</include>
+                    </includes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -135,7 +134,27 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.version}</artifactId>
+            <artifactId>specs2-core_${scala.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-common_${scala.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-matcher_${scala.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/csv-validator-cmd/src/main/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdApp.scala
+++ b/csv-validator-cmd/src/main/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdApp.scala
@@ -149,16 +149,16 @@ object CsvValidatorCmdApp extends App {
 
   private def containsError(l: NonEmptyList[FailMessage]) : Boolean = {
     l.list.find(_ match {
-      case ErrorMessage(_, _, _) => true
+      case FailMessage(ValidationError, _, _, _) => true
       case _ => false
     }).nonEmpty
   }
 
   private def prettyPrint(l: NonEmptyList[FailMessage]): String = l.list.map { i =>
     i match {
-      case WarningMessage(err,_,_) => "Warning: " + err
-      case ErrorMessage(err,_,_) =>   "Error:   " + err
-      case SchemaMessage(err,_,_) =>  err
+      case FailMessage(ValidationWarning, err,_,_) => "Warning: " + err
+      case FailMessage(ValidationError, err,_,_) =>   "Error:   " + err
+      case FailMessage(SchemaDefinitionError, err,_,_) =>  err
     }
-  }.mkString(sys.props("line.separator"))
+  }.toList.mkString(sys.props("line.separator"))
 }

--- a/csv-validator-cmd/src/test/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdAppSpec.scala
+++ b/csv-validator-cmd/src/test/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdAppSpec.scala
@@ -8,8 +8,11 @@
  */
 package uk.gov.nationalarchives.csv.validator.cmd
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class CsvValidatorCmdAppSpec extends Specification with TestResources {
 
   val schemaPath = relResourcePath("schema.csvs")

--- a/csv-validator-core/pom.xml
+++ b/csv-validator-core/pom.xml
@@ -32,6 +32,8 @@
                     <useZincServer>true</useZincServer>          <!-- NOTE: if you have Zinc server installed and running, you can get faster compilation by enabling this -->
                     <args>
                         <arg>-Yrangepos</arg> <!-- recommended for Specs2 -->
+                        <arg>-feature</arg>
+                        <arg>-deprecation</arg>
                     </args>
                     <javacArgs>
                         <javacArg>-Xlint:unchecked</javacArg>
@@ -78,6 +80,10 @@
                         <include>**/*Spec.*</include>
                     </includes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/csv-validator-core/pom.xml
+++ b/csv-validator-core/pom.xml
@@ -99,18 +99,13 @@
         <dependency>
             <groupId>org.scalaz.stream</groupId>
             <artifactId>scalaz-stream_${scala.version}</artifactId>
-            <version>0.6a</version>     <!-- version 0.5a is compatible with scalaz-core 7.1.0 -->
+            <version>0.7.3a</version>
         </dependency>
         <dependency>
-            <groupId>org.typelevel</groupId>
-            <artifactId>scodec-bits_${scala.version}</artifactId>
-            <version>1.0.4</version>
-        </dependency>
-        <!-- dependency>
             <groupId>org.scodec</groupId>
             <artifactId>scodec-bits_${scala.version}</artifactId>
             <version>1.0.6</version>
-        </dependency -->
+        </dependency>
         <dependency>
             <groupId>org.scalaz</groupId>
             <artifactId>scalaz-concurrent_${scala.version}</artifactId>

--- a/csv-validator-core/pom.xml
+++ b/csv-validator-core/pom.xml
@@ -30,6 +30,9 @@
                 <configuration>
                     <recompileMode>incremental</recompileMode>   <!-- NOTE: incremental compilation although faster requires passing to MAVEN_OPTS="-XX:MaxPermSize=128m" -->
                     <useZincServer>true</useZincServer>          <!-- NOTE: if you have Zinc server installed and running, you can get faster compilation by enabling this -->
+                    <args>
+                        <arg>-Yrangepos</arg> <!-- recommended for Specs2 -->
+                    </args>
                     <javacArgs>
                         <javacArg>-Xlint:unchecked</javacArg>
                         <javacArg>-Xlint:deprecation</javacArg>
@@ -68,17 +71,13 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.mmakowski</groupId>
-                <artifactId>maven-specs2-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>verify</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>run-specs</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*Spec.*</include>
+                    </includes>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -156,7 +155,27 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2_${scala.version}</artifactId>
+            <artifactId>specs2-core_${scala.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-common_${scala.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-matcher_${scala.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/FailFastMetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/FailFastMetaDataValidator.scala
@@ -22,9 +22,11 @@ import uk.gov.nationalarchives.csv.validator.metadata.Row
 
 trait FailFastMetaDataValidator extends MetaDataValidator {
 
+  //TODO(AR) work on removing use of `Any`
+
   override def validateRows(rows: Iterator[Row], schema: Schema): MetaDataValidation[Any] = {
 
-    def containsErrors(e: MetaDataValidation[Any]): Boolean = e.fold(_.list.exists(_.isInstanceOf[ErrorMessage]), _ => false)
+    def containsErrors(e: MetaDataValidation[Any]): Boolean = e.fold(_.list.collectFirst(FailMessage.isError).nonEmpty, _ => false)
 
     @tailrec
     def validateRows(results: List[MetaDataValidation[Any]] = List.empty[MetaDataValidation[Any]]) : List[MetaDataValidation[Any]] = {

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidator.scala
@@ -11,7 +11,7 @@ package uk.gov.nationalarchives.csv.validator
 
 import uk.gov.nationalarchives.utf8.validator.{Utf8Validator, ValidationHandler}
 
-import scala.language.postfixOps
+import scala.language.{postfixOps, reflectiveCalls}
 import scala.util.Try
 import scalaz._, Scalaz._
 import java.io.{IOException, Reader => JReader, InputStreamReader => JInputStreamReader, FileInputStream => JFileInputStream, LineNumberReader => JLineNumberReader}

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/Util.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/Util.scala
@@ -26,9 +26,9 @@ object Util {
 
   def checkFilesReadable(files: List[Path]) = files.map(fileReadable).sequence[AppValidation, FailMessage]
 
-  def fileReadable(file: Path): AppValidation[FailMessage] = if (file.exists && file.canRead) SchemaMessage(file.path).successNel[FailMessage] else fileNotReadableMessage(file).failureNel[FailMessage]
+  def fileReadable(file: Path): AppValidation[FailMessage] = if (file.exists && file.canRead) FailMessage(SchemaDefinitionError, file.path).successNel[FailMessage] else fileNotReadableMessage(file).failureNel[FailMessage]
 
-  def fileNotReadableMessage(file: Path) = SchemaMessage("Unable to read file : " + file.path)
+  def fileNotReadableMessage(file: Path) = FailMessage(SchemaDefinitionError, "Unable to read file : " + file.path)
 
   /**
     * Check if the list l1 contain all element in l2

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/Util.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/Util.scala
@@ -8,7 +8,7 @@
  */
 package uk.gov.nationalarchives.csv.validator
 
-import scala.collection.mutable
+import scala.language.postfixOps
 import scalax.file.Path
 import scalaz._
 import Scalaz._

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaParser.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaParser.scala
@@ -18,13 +18,14 @@ import java.io.Reader
 import scalaz._
 import Scalaz._
 
-import uk.gov.nationalarchives.csv.validator.{SchemaMessage, FailMessage}
+import uk.gov.nationalarchives.csv.validator.{SchemaDefinitionError, FailMessage}
 
 /**
   * CSV Schema Parser
   *
   * Uses Scala Parser Combinators to parse the CSV Schema language defined in
   * the specification document
+  *
   * @see http://digital-preservation.github.io/csv-validator/csv-schema-1.0.html
   */
 trait SchemaParser extends RegexParsers
@@ -122,9 +123,9 @@ with TraceableParsers {
     parse(reader) match {
       case s @ Success(schema: Schema, next) => {
         val errors = SchemaValidator.validate(schema)
-        if (errors.isEmpty) schema.successNel[FailMessage] else SchemaMessage(errors).failureNel[Schema]
+        if (errors.isEmpty) schema.successNel[FailMessage] else FailMessage(SchemaDefinitionError, errors).failureNel[Schema]
       }
-      case n: NoSuccess => SchemaMessage(formatNoSuccessMessageForPlatform(n.toString)).failureNel[Schema]
+      case n: NoSuccess => FailMessage(SchemaDefinitionError, formatNoSuccessMessageForPlatform(n.toString)).failureNel[Schema]
     }
   }
 

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/Rule.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/Rule.scala
@@ -384,7 +384,7 @@ case class ChecksumRule(rootPath: ArgProvider, file: ArgProvider, algorithm: Str
         .pipe(getHash(algorithm))
         .map(_.toHex)
         .runLast
-        .attemptRun
+        .unsafePerformSyncAttempt
         .validation
         .leftMap(_.getMessage)
         .rightMap(_.getOrElse("NO CHECKSUM"))

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParser.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParser.scala
@@ -10,6 +10,7 @@ package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
 import java.io.Reader
 
+import scala.language.reflectiveCalls
 import uk.gov.nationalarchives.csv.validator.schema.{SchemaParser => BaseSchemaParser, _}
 
 /**

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/SchemaParser.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/SchemaParser.scala
@@ -8,6 +8,7 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_1
 
+import scala.language.reflectiveCalls
 import uk.gov.nationalarchives.csv.validator.schema.v1_0.{SchemaParser => SchemaParser1_0}
 import uk.gov.nationalarchives.csv.validator.schema._
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
@@ -8,7 +8,9 @@
  */
 package uk.gov.nationalarchives.csv.validator
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import scalaz._
 import uk.gov.nationalarchives.csv.validator.schema.Schema
 import uk.gov.nationalarchives.csv.validator.api.{TextFile, CsvValidator}
@@ -16,7 +18,7 @@ import scalax.file.Path
 import java.io.StringReader
 import java.io
 
-
+@RunWith(classOf[JUnitRunner])
 class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   val base = acceptancePath

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
@@ -96,8 +96,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail when @noHeader not set" in {
       validate(TextFile(Path.fromString(base) / "regexRuleFailMetaData.csv"), parse(base + "/regexRuleSchemaWithoutNoHeaderSet.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("regex(\"[0-9]+\") fails for line: 1, column: Age, value: \"twenty\"",Some(1),Some(1))
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, "regex(\"[0-9]+\") fails for line: 1, column: Age, value: \"twenty\"",Some(1),Some(1))
         )
       }
     }
@@ -106,9 +106,9 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
   "Multiple errors " should {
     "all be reported" in {
       validate(TextFile(Path.fromString(base) / "multipleErrorsMetaData.csv"), parse(base + "/regexRuleSchemaWithNoHeaderSet.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""regex("[0-9]+") fails for line: 1, column: Age, value: "twenty"""",Some(1),Some(1)),
-          ErrorMessage("""regex("[0-9]+") fails for line: 2, column: Age, value: "thirty"""",Some(2),Some(1)))
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, """regex("[0-9]+") fails for line: 1, column: Age, value: "twenty"""",Some(1),Some(1)),
+          FailMessage(ValidationError, """regex("[0-9]+") fails for line: 2, column: Age, value: "thirty"""",Some(2),Some(1)))
       }
     }
   }
@@ -122,11 +122,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail when rules fail for all permutations" in {
       validate(TextFile(Path.fromString(base) / "twoRulesFailMetaData.csv"), parse(base + "/twoRuleSchemaFail.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""in($FullName) fails for line: 1, column: Name, value: "Ben"""",Some(1),Some(0)),
-          ErrorMessage("""regex("[a-z]+") fails for line: 1, column: Name, value: "Ben"""",Some(1),Some(0)),
-          ErrorMessage("""in($FullName) fails for line: 2, column: Name, value: "Dave"""",Some(2),Some(0)),
-          ErrorMessage("""regex("[a-z]+") fails for line: 2, column: Name, value: "Dave"""",Some(2),Some(0)))
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, """in($FullName) fails for line: 1, column: Name, value: "Ben"""",Some(1),Some(0)),
+          FailMessage(ValidationError, """regex("[a-z]+") fails for line: 1, column: Name, value: "Ben"""",Some(1),Some(0)),
+          FailMessage(ValidationError, """in($FullName) fails for line: 2, column: Name, value: "Dave"""",Some(2),Some(0)),
+          FailMessage(ValidationError, """regex("[a-z]+") fails for line: 2, column: Name, value: "Dave"""",Some(2),Some(0)))
       }
     }
   }
@@ -142,16 +142,16 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if the conditionExpr is true but the thenExpr is false" in {
       validate(TextFile(Path.fromString(base) / "ifRuleFailThenMetaData.csv"), parse(base + "/ifElseRuleSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""is("hello world") fails for line: 1, column: SomeIfRule, value: "hello world1"""",Some(1),Some(1))
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, """is("hello world") fails for line: 1, column: SomeIfRule, value: "hello world1"""",Some(1),Some(1))
         )
       }
     }
 
     "fail if the conditionExpr is fasle but the elseExpr is false" in {
       validate(TextFile(Path.fromString(base) / "ifRuleFailElseMetaData.csv"), parse(base + "/ifElseRuleSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""upperCase fails for line: 3, column: SomeIfRule, value: "EFQWeGW"""",Some(3),Some(1))
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, """upperCase fails for line: 3, column: SomeIfRule, value: "EFQWeGW"""",Some(3),Some(1))
         )
       }
     }
@@ -168,17 +168,17 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if the conditionExpr is true but the thenExpr is false - 1" in {
       validate(TextFile(Path.fromString(base) / "switch1RuleFailMetaData.csv"), parse(base + "/switch1RuleSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""is("hello world") fails for line: 1, column: SomeSwitchRule, value: "hello world1"""",Some(1),Some(1))
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, """is("hello world") fails for line: 1, column: SomeSwitchRule, value: "hello world1"""",Some(1),Some(1))
         )
       }
     }
 
     "fail if the conditionExpr is true but the thenExpr is false - 2" in {
       validate(TextFile(Path.fromString(base) / "switch2RuleFailMetaData.csv"), parse(base + "/switch2RuleSchema.csvs"), None) must beLike {
-        case Failure(errors) =>errors.list mustEqual List(
-          ErrorMessage("""is("hello world") fails for line: 1, column: SomeSwitchRule, value: "hello world1"""",Some(1),Some(1)),
-          ErrorMessage("""is("HELLO WORLD") fails for line: 2, column: SomeSwitchRule, value: "HELLO WORLD1"""",Some(2),Some(1))
+        case Failure(errors) =>errors.list mustEqual IList(
+          FailMessage(ValidationError, """is("hello world") fails for line: 1, column: SomeSwitchRule, value: "hello world1"""",Some(1),Some(1)),
+          FailMessage(ValidationError, """is("HELLO WORLD") fails for line: 2, column: SomeSwitchRule, value: "HELLO WORLD1"""",Some(2),Some(1))
         )
       }
     }
@@ -195,9 +195,9 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if the column value is not in the rule's literal string" in {
       validate(TextFile(Path.fromString(base) / "inRuleFailMetaData.csv"), parse(base + "/inRuleSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""in("thevaluemustbeinthisstring") fails for line: 1, column: SomeInRule, value: "valuenotinrule"""",Some(1),Some(1)),
-          ErrorMessage("""in("thevaluemustbeinthisstring") fails for line: 3, column: SomeInRule, value: "thisonewillfailtoo"""",Some(3),Some(1)))
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, """in("thevaluemustbeinthisstring") fails for line: 1, column: SomeInRule, value: "valuenotinrule"""",Some(1),Some(1)),
+          FailMessage(ValidationError, """in("thevaluemustbeinthisstring") fails for line: 3, column: SomeInRule, value: "thisonewillfailtoo"""",Some(3),Some(1)))
       }
     }
 
@@ -209,7 +209,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if the column value is not in the rule's cross referenced column" in {
       validate(TextFile(Path.fromString(base) / "inRuleCrossReferenceFailMetaData.csv"), parse(base + "/inRuleCrossReferenceSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""in($FullName) fails for line: 2, column: FirstName, value: "Dave"""",Some(2),Some(0)))
+        case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """in($FullName) fails for line: 2, column: FirstName, value: "Dave"""",Some(2),Some(0)))
       }
     }
   }
@@ -221,8 +221,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if the column value is not in the rule's literal string" in {
       validate(TextFile(Path.fromString(base) / "anyRuleFailMetaData.csv"), parse(base + "/anyRuleSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""any("value1", "value2", "value3") fails for line: 4, column: SomeAnyRule, value: "value4"""",Some(4),Some(1))
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, """any("value1", "value2", "value3") fails for line: 4, column: SomeAnyRule, value: "value4"""",Some(4),Some(1))
         )
       }
     }
@@ -235,8 +235,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if the column value is not in the rule's literal string" in {
       validate(TextFile(Path.fromString(base) / "xsdDateTimeFail.csv"), parse(base + "/xsdDateTime.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""xDateTime fails for line: 2, column: date, value: "2013-03-22"""",Some(2),Some(0))
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, """xDateTime fails for line: 2, column: date, value: "2013-03-22"""",Some(2),Some(0))
         )
       }
     }
@@ -249,8 +249,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if the column value is not in the rule's literal string" in {
       validate(TextFile(Path.fromString(base) / "xsdDateTimeRangeFail.csv"), parse(base + "/xsdDateTimeRange.csvs"), None) must beLike {
-        case Failure(errors) => errors.list  mustEqual List(
-          ErrorMessage("""xDateTime("2012-01-01T01:00:00, 2013-01-01T01:00:00") fails for line: 2, column: date, value: "2014-01-01T01:00:00"""",Some(2),Some(0))
+        case Failure(errors) => errors.list  mustEqual IList(
+          FailMessage(ValidationError, """xDateTime("2012-01-01T01:00:00, 2013-01-01T01:00:00") fails for line: 2, column: date, value: "2014-01-01T01:00:00"""",Some(2),Some(0))
         )
       }
     }
@@ -264,8 +264,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if the column value is invalid" in {
       validate(TextFile(Path.fromString(base) / "xsdDateTimeTzFail.csv"), parse(base + "/xsdDateTimeTz.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""xDateTimeWithTimeZone fails for line: 4, column: date, value: "2012-01-01T00:00:00"""",Some(4),Some(0))
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, """xDateTimeWithTimeZone fails for line: 4, column: date, value: "2012-01-01T00:00:00"""",Some(4),Some(0))
         )
       }
     }
@@ -278,8 +278,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if the column value is not in the rule's literal string" in {
       validate(TextFile(Path.fromString(base) / "xsdDateTimeTzRangeFail.csv"), parse(base + "/xsdDateTimeTzRange.csvs"), None) must beLike {
-        case Failure(errors) => errors.list  mustEqual List(
-          ErrorMessage("""xDateTimeWithTimeZone("2012-01-01T01:00:00+00:00, 2013-01-01T01:00:00+00:00") fails for line: 2, column: date, value: "2014-01-01T01:00:00+00:00"""",Some(2),Some(0))
+        case Failure(errors) => errors.list  mustEqual IList(
+          FailMessage(ValidationError, """xDateTimeWithTimeZone("2012-01-01T01:00:00+00:00, 2013-01-01T01:00:00+00:00") fails for line: 2, column: date, value: "2014-01-01T01:00:00+00:00"""",Some(2),Some(0))
         )
       }
     }
@@ -296,7 +296,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if a non empty value fails a rule" in {
       validate(TextFile(Path.fromString(base) / "optionalFailMetaData.csv"), parse(base + "/optionalSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("in($FullName) fails for line: 1, column: Name, value: \"BP\"",Some(1),Some(0)))
+        case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, "in($FullName) fails for line: 1, column: Name, value: \"BP\"",Some(1),Some(0)))
       }
     }
   }
@@ -334,9 +334,9 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if the file does not exist on the file system" in {
       validate(TextFile(Path.fromString(base) / "fileExistsPassMetaData.csv"), parse(base + "/fileExistsSchemaWithBadBasePath.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""fileExists("src/test/resources/uk/gov/nationalarchives") fails for line: 1, column: PasswordFile, value: "benPass.csvs"""",Some(1),Some(2)),
-          ErrorMessage("""fileExists("src/test/resources/uk/gov/nationalarchives") fails for line: 2, column: PasswordFile, value: "andyPass.csvs"""",Some(2),Some(2)))
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, """fileExists("src/test/resources/uk/gov/nationalarchives") fails for line: 1, column: PasswordFile, value: "benPass.csvs"""",Some(1),Some(2)),
+          FailMessage(ValidationError, """fileExists("src/test/resources/uk/gov/nationalarchives") fails for line: 2, column: PasswordFile, value: "andyPass.csvs"""",Some(2),Some(2)))
       }
     }
 
@@ -347,9 +347,9 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
       val csfSchema = csfSchemaTemplate.replace("$$acceptancePath$$", base)
 
       validateE(TextFile(Path.fromString(base) / "caseSensitiveFiles.csv"), parseE(new StringReader(csfSchema)), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""fileExists("$$acceptance$$") fails for line: 2, column: filename, value: "casesensitivefiles.csv"""".replace("$$acceptance$$", base),Some(2),Some(0)),
-          ErrorMessage("""fileExists("$$acceptance$$") fails for line: 3, column: filename, value: "CASESENSITIVEFILES.csv"""".replace("$$acceptance$$", base),Some(3),Some(0))
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, """fileExists("$$acceptance$$") fails for line: 2, column: filename, value: "casesensitivefiles.csv"""".replace("$$acceptance$$", base),Some(2),Some(0)),
+          FailMessage(ValidationError, """fileExists("$$acceptance$$") fails for line: 3, column: filename, value: "CASESENSITIVEFILES.csv"""".replace("$$acceptance$$", base),Some(3),Some(0))
         )
       }
     }
@@ -363,20 +363,20 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "enforce all element in a call on to be in a range of value" in {
       validate(TextFile(Path.fromString(base) / "rangeRuleFailMetaData.csv"), parse(base + "/rangeRuleSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""range(1910,*) fails for line: 2, column: Year_of_birth, value: "1909"""",Some(2),Some(1)))
+        case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """range(1910,*) fails for line: 2, column: Year_of_birth, value: "1909"""",Some(2),Some(1)))
       }
     }
 
     "fail with no limit set" in {
       parseSchema(TextFile(Path.fromString(base) / "rangeRuleFailSchema.csvs")) must beLike {
-        case Failure(errors) => errors.list mustEqual List(SchemaMessage("""Column: Year_of_birth: Invalid range in 'range(*,*)' at least one value needs to be defined""",None,None))
+        case Failure(errors) => errors.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: Year_of_birth: Invalid range in 'range(*,*)' at least one value needs to be defined""",None,None))
       }
     }
 
 
     "fail with inconsistent limit" in {
       parseSchema(TextFile(Path.fromString(base) / "rangeRuleInvalidSchema.csvs")) must beLike {
-        case Failure(errors) => errors.list mustEqual List(SchemaMessage("""Column: Year_of_birth: Invalid range, minimum greater than maximum in: 'range(100,1)' at line: 4, column: 16""",None,None))
+        case Failure(errors) => errors.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: Year_of_birth: Invalid range, minimum greater than maximum in: 'range(100,1)' at line: 4, column: 16""",None,None))
       }
     }
   }
@@ -390,9 +390,9 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
       val csfSchema = csfSchemaTemplate.replace("$$acceptancePath$$", base)
 
       validateE(TextFile(Path.fromString(base) / "caseSensitiveFilesChecksum.csv"), parseE(new StringReader(csfSchema)), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""checksum(file("$$acceptance$$", $filename), "MD5") file "$$acceptance$$$$file-sep$$casesensitivefileschecksum.csvs" not found for line: 2, column: checksum, value: "41424313f6052b7f062358ed38640b6e"""".replace("$$acceptance$$", base).replace("$$file-sep$$", FILE_SEPARATOR.toString),Some(2),Some(1)),
-          ErrorMessage("""checksum(file("$$acceptance$$", $filename), "MD5") file "$$acceptance$$$$file-sep$$CASESENSITIVEFILESCHECKSUM.csvs" not found for line: 3, column: checksum, value: "41424313f6052b7f062358ed38640b6e"""".replace("$$acceptance$$", base).replace("$$file-sep$$", FILE_SEPARATOR.toString),Some(3),Some(1))
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, """checksum(file("$$acceptance$$", $filename), "MD5") file "$$acceptance$$$$file-sep$$casesensitivefileschecksum.csvs" not found for line: 2, column: checksum, value: "41424313f6052b7f062358ed38640b6e"""".replace("$$acceptance$$", base).replace("$$file-sep$$", FILE_SEPARATOR.toString),Some(2),Some(1)),
+          FailMessage(ValidationError, """checksum(file("$$acceptance$$", $filename), "MD5") file "$$acceptance$$$$file-sep$$CASESENSITIVEFILESCHECKSUM.csvs" not found for line: 3, column: checksum, value: "41424313f6052b7f062358ed38640b6e"""".replace("$$acceptance$$", base).replace("$$file-sep$$", FILE_SEPARATOR.toString),Some(3),Some(1))
         )
       }
     }
@@ -410,8 +410,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail for different rows in the same column  " in {
       validateE(TextFile(Path.fromString(base) / "identicalFailMetaData.csv"), parseE(base + "/identicalSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(
-          ErrorMessage("""identical fails for line: 3, column: FullName, value: "fff"""",Some(3),Some(1))
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, """identical fails for line: 3, column: FullName, value: "fff"""",Some(3),Some(1))
         )
       }
     }
@@ -427,13 +427,13 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "only report first error for invalid @TotalColumns" in {
       app.validate(TextFile(Path.fromString(base) / "totalColumnsFailMetaData.csv"), parse(base + "/totalColumnsSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("Expected @totalColumns of 1 and found 2 on line 2",Some(2),Some(2)))
+        case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, "Expected @totalColumns of 1 and found 2 on line 2",Some(2),Some(2)))
       }
     }
 
     "only report first rule fail for multiple rules on a column" in {
       app.validate(TextFile(Path.fromString(base) / "rulesFailMetaData.csv"), parse(base + "/rulesSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z][a-z]+") fails for line: 2, column: Name, value: "ben"""",Some(2),Some(0)))
+        case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """regex("[A-Z][a-z]+") fails for line: 2, column: Name, value: "ben"""",Some(2),Some(0)))
       }
     }
 
@@ -446,19 +446,19 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "report warnings" in {
       app.validate(TextFile(Path.fromString(base) / "warnings.csv"), parse(base + "/warnings.csvs"), None) must beLike {
-        case Failure(warnings) => warnings.list mustEqual List(
-          WarningMessage("""is("WO") fails for line: 2, column: department, value: "BT"""", Some(2), Some(0)),
-          WarningMessage("""is("WO") fails for line: 3, column: department, value: "ED"""", Some(3), Some(0))
+        case Failure(warnings) => warnings.list mustEqual IList(
+          FailMessage(ValidationWarning, """is("WO") fails for line: 2, column: department, value: "BT"""", Some(2), Some(0)),
+          FailMessage(ValidationWarning, """is("WO") fails for line: 3, column: department, value: "ED"""", Some(3), Some(0))
         )
       }
     }
 
     "report warnings and only first error" in {
       app.validate(TextFile(Path.fromString(base) / "warningsAndErrors.csv"), parse(base + "/warnings.csvs"), None) must beLike {
-        case Failure(warningsAndError) => warningsAndError.list mustEqual List(
-          WarningMessage("""is("WO") fails for line: 2, column: department, value: "BT"""", Some(2), Some(0)),
-          WarningMessage("""is("WO") fails for line: 3, column: department, value: "ED"""", Some(3), Some(0)),
-          ErrorMessage("""is("13") fails for line: 4, column: division, value: "15"""", Some(4), Some(1))
+        case Failure(warningsAndError) => warningsAndError.list mustEqual IList(
+          FailMessage(ValidationWarning, """is("WO") fails for line: 2, column: department, value: "BT"""", Some(2), Some(0)),
+          FailMessage(ValidationWarning, """is("WO") fails for line: 3, column: department, value: "ED"""", Some(3), Some(0)),
+          FailMessage(ValidationError, """is("13") fails for line: 4, column: division, value: "15"""", Some(4), Some(1))
         )
       }
     }
@@ -468,7 +468,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail with duplicate column ids" in {
       parseSchema(TextFile(Path.fromString(base) / "duplicateColumnIdsFailSchema.csvs")) must beLike {
-        case Failure(errors) => errors.list mustEqual List(SchemaMessage("""Column: Age has duplicates on lines 3, 8
+        case Failure(errors) => errors.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: Age has duplicates on lines 3, 8
                                                                            |Column: Country has duplicates on lines 4, 5, 7""".stripMargin))
       }
     }
@@ -490,7 +490,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if both the lhs or rhs are fail" in {
       validate(TextFile(Path.fromString(base) / "orWithTwoRulesFailMetaData.csv"), parse(base + "/orWithTwoRulesSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z][a-z]+") or regex("[0-9]+") fails for line: 4, column: CountryOrCountryCode, value: "Andromeda9"""",Some(4),Some(1)))
+        case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """regex("[A-Z][a-z]+") or regex("[0-9]+") fails for line: 4, column: CountryOrCountryCode, value: "Andromeda9"""",Some(4),Some(1)))
       }
     }
 
@@ -502,7 +502,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if 'or' rules pass and 'and' rule fails" in {
       validate(TextFile(Path.fromString(base) / "orWithFourRulesFailMetaData.csv"), parse(base + "/orWithFourRulesSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""regex("[A-Z].+") fails for line: 2, column: Country, value: "ngland"""",Some(2),Some(1)))
+        case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """regex("[A-Z].+") fails for line: 2, column: Country, value: "ngland"""",Some(2),Some(1)))
       }
     }
   }
@@ -516,8 +516,15 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail if all the rules are not" in {
       validate(TextFile(Path.fromString(base) / "standardRulesFailMetaData.csv"), parse(base + "/standardRulesSchema.csvs"), None) must beLike {
-        case Failure(errors) => errors.list.toString() mustEqual """List(ErrorMessage(uri fails for line: 1, column: uri, value: "http:##datagov.nationalarchives.gov.uk#66#WO#409#9999#0#aaaaaaaa-aaaa-4aaa-9eee-0123456789ab",Some(1),Some(0)), ErrorMessage(xDateTime fails for line: 1, column: xDateTime, value: "2002-999-30T09:00:10",Some(1),Some(1)), ErrorMessage(xDate fails for line: 1, column: xDate, value: "02-99-30",Some(1),Some(2)), ErrorMessage(ukDate fails for line: 1, column: ukDate, value: "99/00/0009",Some(1),Some(3)), ErrorMessage(xTime fails for line: 1, column: xTime, value: "99:00:889",Some(1),Some(4)), ErrorMessage(uuid4 fails for line: 1, column: uuid4, value: "aaaaaaaab-aaaab-4aaa-9eee-0123456789ab",Some(1),Some(5)), ErrorMessage(positiveInteger fails for line: 1, column: positiveInteger, value: "12-0912459",Some(1),Some(6)))"""
-
+        case Failure(errors) => errors.list mustEqual IList(
+          FailMessage(ValidationError, """uri fails for line: 1, column: uri, value: "http:##datagov.nationalarchives.gov.uk#66#WO#409#9999#0#aaaaaaaa-aaaa-4aaa-9eee-0123456789ab"""", Some(1), Some(0)),
+          FailMessage(ValidationError, """xDateTime fails for line: 1, column: xDateTime, value: "2002-999-30T09:00:10"""", Some(1), Some(1)),
+          FailMessage(ValidationError, """xDate fails for line: 1, column: xDate, value: "02-99-30"""", Some(1), Some(2)),
+          FailMessage(ValidationError, """ukDate fails for line: 1, column: ukDate, value: "99/00/0009"""", Some(1), Some(3)),
+          FailMessage(ValidationError, """xTime fails for line: 1, column: xTime, value: "99:00:889"""", Some(1), Some(4)),
+          FailMessage(ValidationError, """uuid4 fails for line: 1, column: uuid4, value: "aaaaaaaab-aaaab-4aaa-9eee-0123456789ab"""", Some(1), Some(5)),
+          FailMessage(ValidationError, """positiveInteger fails for line: 1, column: positiveInteger, value: "12-0912459"""", Some(1), Some(6))
+        )
       }
     }
   }
@@ -533,7 +540,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail for incorrect extension removal" in {
       validate(TextFile(Path.fromString(base) / "noextFail.csv"), parse(base + "/noext.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""is(noext($identifier)) fails for line: 3, column: noext, value: "file:/a/b/c.txt"""",Some(3),Some(1)))
+        case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """is(noext($identifier)) fails for line: 3, column: noext, value: "file:/a/b/c.txt"""",Some(3),Some(1)))
       }
     }
   }
@@ -545,7 +552,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail for incorrect concatenation" in {
       validate(TextFile(Path.fromString(base) / "concatFail.csv"), parse(base + "/concat.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""is(concat($c1, $c2)) fails for line: 3, column: c3, value: "ccccc"""",Some(3),Some(2)))
+        case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """is(concat($c1, $c2)) fails for line: 3, column: c3, value: "ccccc"""",Some(3),Some(2)))
       }
     }
 
@@ -555,7 +562,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail for incorrect concatenation (various arguments)" in {
       validate(TextFile(Path.fromString(base) / "concat4Fail.csv"), parse(base + "/concat4.csvs"), None) must beLike {
-        case Failure(errors) =>  errors.list mustEqual List(ErrorMessage("""is(concat($c1, $c2, "hello", $c4)) fails for line: 2, column: c5, value: "aabbccdd"""",Some(2),Some(4)))
+        case Failure(errors) =>  errors.list mustEqual IList(FailMessage(ValidationError, """is(concat($c1, $c2, "hello", $c4)) fails for line: 2, column: c5, value: "aabbccdd"""",Some(2),Some(4)))
       }
     }
   }
@@ -568,7 +575,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "fail for incorrect concatenation" in {
       validate(TextFile(Path.fromString(base) / "redactedFail.csv"), parse(base + "/redacted.csvs"), None) must beLike {
-        case Failure(errors) => errors.list mustEqual List(ErrorMessage("""is(concat(noext($original_identifier), "_R.pdf")) fails for line: 2, column: identifier, value: "file:/some/folder/TNA%20Digital%20Preservation%20Strategy%20v0.3%5BA1031178%5D_R1.pdf"""",Some(2),Some(0)))
+        case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """is(concat(noext($original_identifier), "_R.pdf")) fails for line: 2, column: identifier, value: "file:/some/folder/TNA%20Digital%20Preservation%20Strategy%20v0.3%5BA1031178%5D_R1.pdf"""",Some(2),Some(0)))
       }
     }
   }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorBigFileSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorBigFileSpec.scala
@@ -8,13 +8,16 @@
  */
 package uk.gov.nationalarchives.csv.validator
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import scalaz._
 import uk.gov.nationalarchives.csv.validator.schema.Schema
 import uk.gov.nationalarchives.csv.validator.api.{TextFile, CsvValidator}
 import scalax.file.Path
 import uk.gov.nationalarchives.csv.validator.api.CsvValidator.SubstitutePath
 
+@RunWith(classOf[JUnitRunner])
 class MetaDataValidatorBigFileSpec extends Specification with TestResources {
 
   val base = acceptancePath

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorBusinessAcceptanceSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorBusinessAcceptanceSpec.scala
@@ -8,12 +8,15 @@
  */
 package uk.gov.nationalarchives.csv.validator
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import scalaz._
 import uk.gov.nationalarchives.csv.validator.schema.Schema
 import uk.gov.nationalarchives.csv.validator.api.{TextFile, CsvValidator}
 import scalax.file.Path
 
+@RunWith(classOf[JUnitRunner])
 class MetaDataValidatorBusinessAcceptanceSpec extends Specification with TestResources {
 
   val base = resourcePath("acceptance/dp")

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorChecksumSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorChecksumSpec.scala
@@ -15,7 +15,7 @@ import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.schema._
 import java.io.{Reader, StringReader}
 
-import scalaz.{Success => SuccessZ, Failure => FailureZ, ValidationNel}
+import scalaz.{Success => SuccessZ, Failure => FailureZ, ValidationNel, IList}
 import uk.gov.nationalarchives.csv.validator.schema.Schema
 import uk.gov.nationalarchives.csv.validator.Util.TypedPath
 
@@ -70,7 +70,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = s"$checksumPath,wrong"
 
       validate(metaData, schema, None) must beLike {
-        case FailureZ(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + checksumPath + """"), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "wrong". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
+        case FailureZ(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """checksum(file("""" + checksumPath + """"), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "wrong". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
       }
     }
   }
@@ -100,7 +100,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """ABC,wrong"""
 
       validate(metaData, schema, None) must beLike {
-        case FailureZ(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + schemaPath1_0 + """", "checksum.csvs"), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "wrong". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
+        case FailureZ(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """checksum(file("""" + schemaPath1_0 + """", "checksum.csvs"), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "wrong". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
       }
     }
   }
@@ -131,7 +131,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """checksum.csvs,232762380299115da6995e4c4ac22fa2"""
 
       validate(metaData, schema, None) must beLike {
-        case FailureZ(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("invalid/path/to/root", $File), "MD5") incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
+        case FailureZ(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """checksum(file("invalid/path/to/root", $File), "MD5") incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
       }
     }
 
@@ -161,7 +161,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
         val metaData = s"$checksumPath,rubbish"
 
         validate(metaData, schema, None) must beLike {
-          case FailureZ(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file($File), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "rubbish". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
+          case FailureZ(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """checksum(file($File), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "rubbish". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
         }
       }
     }
@@ -177,7 +177,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """checksum.csvs,rubbish"""
 
       validate(metaData, schema, None) must beLike {
-        case FailureZ(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + schemaPath1_0 + """", $File), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "rubbish". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
+        case FailureZ(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """checksum(file("""" + schemaPath1_0 + """", $File), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: MD5, value: "rubbish". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
       }
     }
   }
@@ -210,7 +210,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """invalid/path/to/root,checksum.csvs,232762380299115da6995e4c4ac22fa2"""
 
       validate(metaData, schema, None) must beLike {
-        case FailureZ(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file($Root, $File), "MD5") incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""", Some(1), Some(2)))
+        case FailureZ(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """checksum(file($Root, $File), "MD5") incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""", Some(1), Some(2)))
       }
     }
   }
@@ -261,7 +261,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       validate(metaData, schema, None) must beLike {
         case FailureZ(messages) =>
           val msg = """checksum(file($Root, $File), "MD5") root """ + searchPath + FILE_SEPARATOR + """ (localfile: """ + searchPath + FILE_SEPARATOR + """checksum.*) should not contain wildcards for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2""""
-          messages.list mustEqual List(ErrorMessage(msg, Some(1), Some(2)))
+          messages.list mustEqual IList(FailMessage(ValidationError, msg, Some(1), Some(2)))
       }
     }
 
@@ -277,7 +277,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """**/*.jp2,"232762380299115da6995e4c4ac22fa2""""
 
       validate(metaData, schema, None) must beLike {
-        case FailureZ(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("""" + threeFilesPath + """", $File), "MD5") multiple files for """ + threeFilesPath + s"""${FILE_SEPARATOR}**${FILE_SEPARATOR}*.jp2 found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
+        case FailureZ(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """checksum(file("""" + threeFilesPath + """", $File), "MD5") multiple files for """ + threeFilesPath + s"""${FILE_SEPARATOR}**${FILE_SEPARATOR}*.jp2 found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
       }
     }
 
@@ -292,7 +292,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val metaData = """**/*.jp2,"232762380299115da6995e4c4ac22fa2""""
 
       validate(metaData, schema, None) must beLike {
-        case FailureZ(messages) => messages.list mustEqual List(ErrorMessage("""checksum(file("src/test/resources/this/is/incorrect", $File), "MD5") incorrect basepath src/test/resources/this/is/incorrect/ (localfile: """ + TypedPath("src/test/resources/this/is/incorrect/**/*.jp2").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
+        case FailureZ(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """checksum(file("src/test/resources/this/is/incorrect", $File), "MD5") incorrect basepath src/test/resources/this/is/incorrect/ (localfile: """ + TypedPath("src/test/resources/this/is/incorrect/**/*.jp2").toPlatform + """) found for line: 1, column: MD5, value: "232762380299115da6995e4c4ac22fa2"""",Some(1),Some(1)))
       }
     }
   }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorChecksumSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorChecksumSpec.scala
@@ -9,7 +9,9 @@
 package uk.gov.nationalarchives.csv.validator
 
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.schema._
 import java.io.{Reader, StringReader}
 
@@ -17,6 +19,7 @@ import scalaz.{Success => SuccessZ, Failure => FailureZ, ValidationNel}
 import uk.gov.nationalarchives.csv.validator.schema.Schema
 import uk.gov.nationalarchives.csv.validator.Util.TypedPath
 
+@RunWith(classOf[JUnitRunner])
 class MetaDataValidatorChecksumSpec extends Specification with TestResources {
 
   implicit def stringToStringReader(s: String): StringReader = new StringReader(s.replaceAll("\n\\s+", "\n"))

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorFileCountSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorFileCountSpec.scala
@@ -8,13 +8,16 @@
  */
 package uk.gov.nationalarchives.csv.validator
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.schema._
 import java.io.{Reader, StringReader}
 import scalaz.Success
 import scalaz.Failure
 import uk.gov.nationalarchives.csv.validator.Util.TypedPath
 
+@RunWith(classOf[JUnitRunner])
 class MetaDataValidatorFileCountSpec extends Specification with TestResources {
 
   implicit def stringToStringReader(s: String): StringReader = new StringReader(s.replaceAll("\n\\s+", "\n"))

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorFileCountSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorFileCountSpec.scala
@@ -13,8 +13,7 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.schema._
 import java.io.{Reader, StringReader}
-import scalaz.Success
-import scalaz.Failure
+import scalaz.{Success, Failure, IList}
 import uk.gov.nationalarchives.csv.validator.Util.TypedPath
 
 @RunWith(classOf[JUnitRunner])
@@ -107,7 +106,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = s"$checksumPath,1"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + wrongPath + """")) file """" + wrongPath + """" not found for line: 1, column: Count, value: "1"""",Some(1),Some(1)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """fileCount(file("""" + wrongPath + """")) file """" + wrongPath + """" not found for line: 1, column: Count, value: "1"""",Some(1),Some(1)))
       }
     }
 
@@ -122,7 +121,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = s"$checksumPath,2"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + checksumPath + """")) found 1 file(s) for line: 1, column: Count, value: "2"""",Some(1),Some(1)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """fileCount(file("""" + checksumPath + """")) found 1 file(s) for line: 1, column: Count, value: "2"""",Some(1),Some(1)))
       }
     }
   }
@@ -153,7 +152,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = """ABC,99"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("""" + schemaPath1_0 + """", "checksum.csvs")) found 1 file(s) for line: 1, column: Count, value: "99"""",Some(1),Some(1)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """fileCount(file("""" + schemaPath1_0 + """", "checksum.csvs")) found 1 file(s) for line: 1, column: Count, value: "99"""",Some(1),Some(1)))
       }
     }
   }
@@ -184,7 +183,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = """checksum.csvs,99"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("invalid/path/to/root", $File)) incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: Count, value: "99"""",Some(1),Some(1)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """fileCount(file("invalid/path/to/root", $File)) incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: Count, value: "99"""",Some(1),Some(1)))
       }
     }
   }
@@ -216,7 +215,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = s"$checksumPath,rubbish"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file($File)) 'rubbish' is not a number for line: 1, column: Count, value: "rubbish"""",Some(1),Some(1)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """fileCount(file($File)) 'rubbish' is not a number for line: 1, column: Count, value: "rubbish"""",Some(1),Some(1)))
       }
     }
   }
@@ -250,7 +249,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = """invalid/path/to/root,checksum.csvs,99"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file($Root, $File)) incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: Count, value: "99"""",Some(1),Some(2)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """fileCount(file($Root, $File)) incorrect basepath invalid/path/to/root/ (localfile: """ + TypedPath("invalid/path/to/root/checksum.csvs").toPlatform + """) found for line: 1, column: Count, value: "99"""",Some(1),Some(2)))
       }
     }
   }
@@ -315,7 +314,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
 
       validate(metaData, schema, None) must beLike {
         case Failure(messages) =>
-          messages.list mustEqual List(ErrorMessage("""fileCount(file($Root, $File)) root """ + searchPath + """/ (localfile: """ + searchPath + FILE_SEPARATOR + """checksum.*) should not contain wildcards for line: 1, column: Count, value: "1"""",Some(1),Some(2)))
+          messages.list mustEqual IList(FailMessage(ValidationError, """fileCount(file($Root, $File)) root """ + searchPath + """/ (localfile: """ + searchPath + FILE_SEPARATOR + """checksum.*) should not contain wildcards for line: 1, column: Count, value: "1"""",Some(1),Some(2)))
       }
     }
 
@@ -343,7 +342,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val metaData = """**/*.jp2,2"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""fileCount(file("src/test/resources/this/is/incorrect", $File)) incorrect basepath src/test/resources/this/is/incorrect/ (localfile: """ + TypedPath("src/test/resources/this/is/incorrect/**/*.jp2").toPlatform + """) found for line: 1, column: Count, value: "2"""",Some(1),Some(1)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """fileCount(file("src/test/resources/this/is/incorrect", $File)) incorrect basepath src/test/resources/this/is/incorrect/ (localfile: """ + TypedPath("src/test/resources/this/is/incorrect/**/*.jp2").toPlatform + """) found for line: 1, column: Count, value: "2"""",Some(1),Some(1)))
       }
     }
   }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorIntegrityCheckSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorIntegrityCheckSpec.scala
@@ -7,14 +7,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package uk.gov.nationalarchives.csv.validator
+
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.api.{CsvValidator, TextFile}
 import uk.gov.nationalarchives.csv.validator.schema.{TraceableParsers, Schema}
 
 import scalax.file.Path
 import scalaz.{Failure, Success}
 
-
+@RunWith(classOf[JUnitRunner])
 class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResources {
 
   def buildValidator(substitutionPath: List[(String,String)]) : CsvValidator = new CsvValidator with AllErrorsMetaDataValidator {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorSpec.scala
@@ -14,8 +14,7 @@ import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.schema._
 import java.io.{Reader, StringReader}
 import uk.gov.nationalarchives.csv.validator.schema.Schema
-import scalaz.Success
-import scalaz.Failure
+import scalaz.{Success, Failure, IList}
 
 @RunWith(classOf[JUnitRunner])
 class MetaDataValidatorSpec extends Specification with TestResources {
@@ -78,7 +77,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("Expected @totalColumns of 3 and found 2 on line 2",Some(2),Some(2)), ErrorMessage("Missing value at line: 2, column: column3",Some(2),Some(2)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, "Expected @totalColumns of 3 and found 2 on line 2",Some(2),Some(2)), FailMessage(ValidationError, "Missing value at line: 2, column: column3",Some(2),Some(2)))
       }
     }
 
@@ -96,10 +95,10 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List (
-          ErrorMessage("""regex("[a-c]*") fails for line: 1, column: second, value: "xxxy"""",Some(1),Some(1)),
-          ErrorMessage("""regex("[3-8]*") fails for line: 2, column: first, value: "abcd"""",Some(2),Some(0)),
-          ErrorMessage("""regex("[a-c]*") fails for line: 2, column: second, value: "uii"""",Some(2),Some(1)))
+        case Failure(messages) => messages.list mustEqual IList (
+          FailMessage(ValidationError, """regex("[a-c]*") fails for line: 1, column: second, value: "xxxy"""",Some(1),Some(1)),
+          FailMessage(ValidationError, """regex("[3-8]*") fails for line: 2, column: first, value: "abcd"""",Some(2),Some(0)),
+          FailMessage(ValidationError, """regex("[a-c]*") fails for line: 2, column: second, value: "uii"""",Some(2),Some(1)))
       }
     }
 
@@ -130,7 +129,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "c11,c12"
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("C11") fails for line: 1, column: Col1, value: "c11"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """regex("C11") fails for line: 1, column: Col1, value: "c11"""",Some(1),Some(0)))
       }
     }
 
@@ -145,7 +144,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "1"
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("Expected @totalColumns of 2 and found 1 on line 1",Some(1),Some(1)), ErrorMessage("Missing value at line: 1, column: Col2",Some(1),Some(1)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, "Expected @totalColumns of 2 and found 1 on line 1",Some(1),Some(1)), FailMessage(ValidationError, "Missing value at line: 1, column: Col2",Some(1),Some(1)))
       }
     }
 
@@ -171,7 +170,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = """Scooby"""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("^T.+") fails for line: 1, column: c1, value: "Scooby"""",Some(1),Some(0)), ErrorMessage("""regex("^X.+") fails for line: 1, column: c1, value: "Scooby"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """regex("^T.+") fails for line: 1, column: c1, value: "Scooby"""",Some(1),Some(0)), FailMessage(ValidationError, """regex("^X.+") fails for line: 1, column: c1, value: "Scooby"""",Some(1),Some(0)))
       }
     }
 
@@ -218,7 +217,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
            blah_andMustBeIn,andMustBeIn"""
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in($col1) fails for line: 1, column: col2WithRule, value: "mustBeIn"""",Some(1),Some(1)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """in($col1) fails for line: 1, column: col2WithRule, value: "mustBeIn"""",Some(1),Some(1)))
       }
     }
 
@@ -263,7 +262,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "1,a,3"
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("[0-9]") fails for line: 1, column: Col2, value: "a"""",Some(1),Some(1)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """regex("[0-9]") fails for line: 1, column: Col2, value: "a"""",Some(1),Some(1)))
       }
     }
 
@@ -283,10 +282,10 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(
-          ErrorMessage("""regex("[0-9]") fails for line: 1, column: Col3, value: """"",Some(1),Some(2)),
-          ErrorMessage("""regex("[0-9]") fails for line: 2, column: Col2, value: "a"""",Some(2),Some(1)),
-          ErrorMessage("""regex("[0-9]") fails for line: 2, column: Col3, value: """"",Some(2),Some(2)))
+        case Failure(messages) => messages.list mustEqual IList(
+          FailMessage(ValidationError, """regex("[0-9]") fails for line: 1, column: Col3, value: """"",Some(1),Some(2)),
+          FailMessage(ValidationError, """regex("[0-9]") fails for line: 2, column: Col2, value: "a"""",Some(2),Some(1)),
+          FailMessage(ValidationError, """regex("[0-9]") fails for line: 2, column: Col3, value: """"",Some(2),Some(2)))
       }
     }
 
@@ -324,7 +323,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "SCOOBY"
 
       validate(metaData, schema, None) should beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""regex("[a-z]+") fails for line: 1, column: Col1, value: "SCOOBY"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """regex("[a-z]+") fails for line: 1, column: Col1, value: "SCOOBY"""",Some(1),Some(0)))
       }
     }
 
@@ -366,7 +365,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "some/non/existent/file"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("fileExists fails for line: 1, column: FirstColumn, value: \"some/non/existent/file\"",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, "fileExists fails for line: 1, column: FirstColumn, value: \"some/non/existent/file\"",Some(1),Some(0)))
       }
     }
 
@@ -384,7 +383,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in("dog") fails for line: 1, column: col2WithRule, value: "thisisrubbish"""",Some(1),Some(1)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """in("dog") fails for line: 1, column: col2WithRule, value: "thisisrubbish"""",Some(1),Some(1)))
       }
     }
 
@@ -399,7 +398,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = ""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file is empty but this has not been permitted"))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, "metadata file is empty but this has not been permitted"))
       }
     }
 
@@ -428,7 +427,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = ""
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file is empty but should contain at least a header"))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, "metadata file is empty but should contain at least a header"))
       }
     }
 
@@ -455,7 +454,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "Name"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("metadata file has a header but no data and this has not been permitted"))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, "metadata file has a header but no data and this has not been permitted"))
       }
     }
 
@@ -484,7 +483,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "SomethingElse"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""in("This") or in("That") fails for line: 1, column: ThisOrThat, value: "SomethingElse"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """in("This") or in("That") fails for line: 1, column: ThisOrThat, value: "SomethingElse"""",Some(1),Some(0)))
       }
     }
 
@@ -550,7 +549,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "UK"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""is("France") fails for line: 1, column: Country, value: "UK"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """is("France") fails for line: 1, column: Country, value: "UK"""",Some(1),Some(0)))
       }
     }
 
@@ -565,7 +564,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United,United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""is($MyCountry) fails for line: 1, column: Country, value: "United"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """is($MyCountry) fails for line: 1, column: Country, value: "United"""",Some(1),Some(0)))
       }
     }
 
@@ -616,7 +615,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""not("United Kingdom") fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """not("United Kingdom") fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
       }
     }
 
@@ -631,7 +630,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom,United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""not($MyCountry) fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """not($MyCountry) fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
       }
     }
 
@@ -682,7 +681,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""starts("united") fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """starts("united") fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
       }
     }
 
@@ -697,7 +696,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United,United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""starts($MyCountry) fails for line: 1, column: Country, value: "United"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """starts($MyCountry) fails for line: 1, column: Country, value: "United"""",Some(1),Some(0)))
       }
     }
 
@@ -747,7 +746,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("kingdom") fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """ends("kingdom") fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
       }
     }
 
@@ -762,7 +761,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val metaData = "United Kingdom,States"
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends($MyCountry) fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """ends($MyCountry) fails for line: 1, column: Country, value: "United Kingdom"""",Some(1),Some(0)))
       }
     }
 
@@ -800,7 +799,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("unique fails for line: 4, column: Name, value: \"Jim\" (original at line: 2)",Some(4),Some(0)),ErrorMessage("unique fails for line: 5, column: Name, value: \"Jim\" (original at line: 2)",Some(5),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, "unique fails for line: 4, column: Name, value: \"Jim\" (original at line: 2)",Some(4),Some(0)),FailMessage(ValidationError, "unique fails for line: 5, column: Name, value: \"Jim\" (original at line: 2)",Some(5),Some(0)))
       }
     }
 
@@ -999,7 +998,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("range(18,65) fails for line: 1, column: Age, value: \"10\"",Some(1),Some(1)),ErrorMessage("range(18,65) fails for line: 3, column: Age, value: \"96\"",Some(3),Some(1)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, "range(18,65) fails for line: 1, column: Age, value: \"10\"",Some(1),Some(1)),FailMessage(ValidationError, "range(18,65) fails for line: 3, column: Age, value: \"96\"",Some(3),Some(1)))
       }
     }
 
@@ -1017,7 +1016,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("length(*,3) fails for line: 3, column: Name, value: \"Benny\"",Some(3),Some(0)),ErrorMessage("length(*,3) fails for line: 5, column: Name, value: \"Timmy\"",Some(5),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, "length(*,3) fails for line: 3, column: Name, value: \"Benny\"",Some(3),Some(0)),FailMessage(ValidationError, "length(*,3) fails for line: 5, column: Name, value: \"Timmy\"",Some(5),Some(0)))
       }
     }
 
@@ -1046,7 +1045,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
 
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""(length(5) and length(*,*)) and is("Hello") fails for line: 2, column: Name, value: "World"""",Some(2),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """(length(5) and length(*,*)) and is("Hello") fails for line: 2, column: Name, value: "World"""",Some(2),Some(0)))
       }
     }
 
@@ -1124,7 +1123,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
       val metaData ="Joe Bloggs"
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("Joe") fails for line: 1, column: col1, value: "Joe Bloggs"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """ends("Joe") fails for line: 1, column: col1, value: "Joe Bloggs"""",Some(1),Some(0)))
       }
     }
 
@@ -1146,7 +1145,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
       val metaData ="Joe Bloggs"
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""ends("Joe") fails for line: 1, column: col1, value: "Joe Bloggs"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """ends("Joe") fails for line: 1, column: col1, value: "Joe Bloggs"""",Some(1),Some(0)))
       }
     }
 
@@ -1178,7 +1177,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
       val metaData ="Joe Bloggs"
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""length(4) fails for line: 1, column: col1, value: "Joe Bloggs"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """length(4) fails for line: 1, column: col1, value: "Joe Bloggs"""",Some(1),Some(0)))
       }
     }
 
@@ -1221,7 +1220,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
         """
       val metaData ="True"
       validate(metaData, schema, None) must beLike {
-        case Failure(messages) => messages.list mustEqual List(ErrorMessage("""(is("True") or is("True")) and is("False") fails for line: 1, column: col1, value: "True"""",Some(1),Some(0)))
+        case Failure(messages) => messages.list mustEqual IList(FailMessage(ValidationError, """(is("True") or is("True")) and is("False") fails for line: 1, column: col1, value: "True"""",Some(1),Some(0)))
       }
     }
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorSpec.scala
@@ -8,6 +8,7 @@
  */
 package uk.gov.nationalarchives.csv.validator
 
+import scala.language.reflectiveCalls
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorSpec.scala
@@ -8,13 +8,16 @@
  */
 package uk.gov.nationalarchives.csv.validator
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.schema._
 import java.io.{Reader, StringReader}
 import uk.gov.nationalarchives.csv.validator.schema.Schema
 import scalaz.Success
 import scalaz.Failure
 
+@RunWith(classOf[JUnitRunner])
 class MetaDataValidatorSpec extends Specification with TestResources {
 
   implicit def stringToStringReader(s: String): StringReader = new StringReader(s.replaceAll("\n\\s+", "\n"))

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/UtilSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/UtilSpec.scala
@@ -10,10 +10,12 @@ package uk.gov.nationalarchives.csv.validator
 
 import java.io.File
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 
-
-class UtilSpec  extends Specification with TestResources  {
+@RunWith(classOf[JUnitRunner])
+class UtilSpec extends Specification with TestResources  {
 
   "Util" should {
     val base = resourcePath("integrityCheck")

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorFileEncodingSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorFileEncodingSpec.scala
@@ -14,7 +14,7 @@ import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.TestResources
 import org.specs2.mutable.Specification
 import scalaz._
-import uk.gov.nationalarchives.csv.validator.{TestResources, EOL, SchemaMessage, AllErrorsMetaDataValidator}
+import uk.gov.nationalarchives.csv.validator.{TestResources, EOL, AllErrorsMetaDataValidator}
 import uk.gov.nationalarchives.csv.validator.schema.Schema
 import scalax.file.Path
 import uk.gov.nationalarchives.csv.validator.api.CsvValidator.SubstitutePath

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorFileEncodingSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorFileEncodingSpec.scala
@@ -8,7 +8,9 @@
  */
 package uk.gov.nationalarchives.csv.validator.api
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.TestResources
 import org.specs2.mutable.Specification
 import scalaz._
@@ -20,6 +22,7 @@ import uk.gov.nationalarchives.csv.validator.api.CsvValidator.SubstitutePath
 /**
  * Created by rhubner on 11/12/15.
  */
+@RunWith(classOf[JUnitRunner])
 class CsvValidatorFileEncodingSpec extends Specification with TestResources {
 
   "Validation" should {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorSpec.scala
@@ -13,7 +13,7 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import scalaz._
-import uk.gov.nationalarchives.csv.validator.{TestResources, EOL, SchemaMessage, AllErrorsMetaDataValidator}
+import uk.gov.nationalarchives.csv.validator._
 import uk.gov.nationalarchives.csv.validator.schema.Schema
 import scalax.file.Path
 import uk.gov.nationalarchives.csv.validator.api.CsvValidator.SubstitutePath
@@ -34,7 +34,7 @@ class CsvValidatorSpec extends Specification with TestResources {
 
       app.parseAndValidate(new StringReader(schema)) must beLike {
         case Failure(msgs) =>
-          msgs.list mustEqual List(SchemaMessage(
+          msgs.list mustEqual IList(FailMessage(SchemaDefinitionError,
           "[3.7] failure: Invalid column definition" + EOL
           + EOL
           + """Name: regox("A")""" + EOL

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorSpec.scala
@@ -9,13 +9,16 @@
 package uk.gov.nationalarchives.csv.validator.api
 
 import java.io.StringReader
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import scalaz._
 import uk.gov.nationalarchives.csv.validator.{TestResources, EOL, SchemaMessage, AllErrorsMetaDataValidator}
 import uk.gov.nationalarchives.csv.validator.schema.Schema
 import scalax.file.Path
 import uk.gov.nationalarchives.csv.validator.api.CsvValidator.SubstitutePath
 
+@RunWith(classOf[JUnitRunner])
 class CsvValidatorSpec extends Specification with TestResources {
 
   "Parsing schema" should {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/DateRulesSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/DateRulesSpec.scala
@@ -8,7 +8,9 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema.v1_0._
 import uk.gov.nationalarchives.csv.validator.schema.v1_1.{XsdDateTimeWithTimeZoneRangeRule, XsdDateTimeWithTimeZoneRule}
@@ -20,6 +22,7 @@ import scalaz.{Failure, Success}
  * User: Jim Collins
  * Date: 3/15/13
  */
+@RunWith(classOf[JUnitRunner])
 class DateRulesSpec extends Specification {
 
   val globalDirsOne = List(TotalColumns(1))

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaSpecBase.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaSpecBase.scala
@@ -12,7 +12,7 @@ import org.specs2.mutable.Specification
 import uk.gov.nationalarchives.csv.validator.schema.v1_0.NotEmptyRule
 
 
-trait SchemaSpecBase  extends Specification {
+trait SchemaSpecBase extends Specification {
 
   object TestSchemaParser extends SchemaParser { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false }
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/AndRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/AndRuleSpec.scala
@@ -14,7 +14,7 @@ import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
-import scalaz.{Failure, Success}
+import scalaz.{Success, Failure, IList}
 
 @RunWith(classOf[JUnitRunner])
 class AndRuleSpec extends Specification {
@@ -30,7 +30,7 @@ class AndRuleSpec extends Specification {
       val andRule = AndRule(leftInRule, rightInRule)
 
       andRule.evaluate(0, Row(List(Cell("Germany")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("""in("Germany") and in("France") fails for line: 1, column: Country, value: "Germany"""")
+        case Failure(messages) => messages.list mustEqual IList("""in("Germany") and in("France") fails for line: 1, column: Country, value: "Germany"""")
       }
     }
 
@@ -44,7 +44,7 @@ class AndRuleSpec extends Specification {
       val andRule = AndRule(leftInRule, rightInRule)
 
       andRule.evaluate(0, Row(List(Cell("France")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("""in("Germany") and in("France") fails for line: 1, column: Country, value: "France"""")
+        case Failure(messages) => messages.list mustEqual IList("""in("Germany") and in("France") fails for line: 1, column: Country, value: "France"""")
       }
     }
 
@@ -58,7 +58,7 @@ class AndRuleSpec extends Specification {
       val andRule = AndRule(leftInRule, rightInRule)
 
       andRule.evaluate(0, Row(List(Cell("SomethingElse")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("""in("This") and in("That") fails for line: 1, column: ThisOrThat, value: "SomethingElse"""")
+        case Failure(messages) => messages.list mustEqual IList("""in("This") and in("That") fails for line: 1, column: ThisOrThat, value: "SomethingElse"""")
       }
     }
 
@@ -102,7 +102,7 @@ class AndRuleSpec extends Specification {
       val andRule = AndRule(leftInRule, rightInRule)
 
       andRule.evaluate(0, Row(List(Cell("SomethingElse")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("""is("UK") and (is("UK") is("UK1")) fails for line: 1, column: Country, value: "SomethingElse"""")
+        case Failure(messages) => messages.list mustEqual IList("""is("UK") and (is("UK") is("UK1")) fails for line: 1, column: Country, value: "SomethingElse"""")
       }
     }
   }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/AndRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/AndRuleSpec.scala
@@ -8,12 +8,15 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
 import scalaz.{Failure, Success}
 
+@RunWith(classOf[JUnitRunner])
 class AndRuleSpec extends Specification {
 
   "AndRule" should {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/ChecksumRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/ChecksumRuleSpec.scala
@@ -16,7 +16,7 @@ import uk.gov.nationalarchives.csv.validator.api.CsvValidator.SubstitutePath
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
-import scalaz.{Failure, Success}
+import scalaz.{Success, Failure, IList}
 
 @RunWith(classOf[JUnitRunner])
 class ChecksumRuleSpec extends Specification with TestResources {
@@ -31,7 +31,7 @@ class ChecksumRuleSpec extends Specification with TestResources {
       val checksumRule = new ChecksumRule(Literal(Some(checksumPath)), "MD5", false)
 
       checksumRule.evaluate(0, Row(List(Cell("699d61aff25f16a5560372e610da91ab")), 1), Schema(List(TotalColumns(1), NoHeader()), List(ColumnDefinition(NamedColumnIdentifier("column1"))))) must beLike {
-        case Failure(m) => m.list mustEqual List("""checksum(file("""" + checksumPath + """"), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: column1, value: "699d61aff25f16a5560372e610da91ab". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""")
+        case Failure(m) => m.list mustEqual IList("""checksum(file("""" + checksumPath + """"), "MD5") file """" + checksumPath + """" checksum match fails for line: 1, column: column1, value: "699d61aff25f16a5560372e610da91ab". Computed checksum value:"232762380299115da6995e4c4ac22fa2"""")
       }
     }
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/ChecksumRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/ChecksumRuleSpec.scala
@@ -8,7 +8,9 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.{FILE_SEPARATOR, TestResources}
 import uk.gov.nationalarchives.csv.validator.api.CsvValidator.SubstitutePath
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
@@ -16,6 +18,7 @@ import uk.gov.nationalarchives.csv.validator.schema._
 
 import scalaz.{Failure, Success}
 
+@RunWith(classOf[JUnitRunner])
 class ChecksumRuleSpec extends Specification with TestResources {
 
   override val checksumPath = resourcePath("checksum.csvs")

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/EmptyRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/EmptyRuleSpec.scala
@@ -8,12 +8,15 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema.{ColumnDefinition, NamedColumnIdentifier, Schema, TotalColumns}
 
 import scalaz.{Failure, Success}
 
+@RunWith(classOf[JUnitRunner])
 class EmptyRuleSpec extends Specification {
 
   val globalDirsOne = List(TotalColumns(1))

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/FileCountSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/FileCountSpec.scala
@@ -10,7 +10,9 @@ package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
 import java.io.File
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.{FILE_SEPARATOR, TestResources}
 import uk.gov.nationalarchives.csv.validator.Util.TypedPath
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
@@ -19,7 +21,7 @@ import uk.gov.nationalarchives.csv.validator.schema._
 import scalax.file.{Path, PathSet}
 import scalaz.{Failure, Success, ValidationNel}
 
-
+@RunWith(classOf[JUnitRunner])
 class FileCountSpec extends Specification with TestResources {
 
   override val threeFilesPath = new File(new File(baseResourcePkgPath).getParentFile.getParent, "fileCountTestFiles/threeFiles").getAbsolutePath

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/FileCountSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/FileCountSpec.scala
@@ -19,7 +19,7 @@ import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
 import scalax.file.{Path, PathSet}
-import scalaz.{Failure, Success, ValidationNel}
+import scalaz.{Success, Failure, ValidationNel, IList}
 
 @RunWith(classOf[JUnitRunner])
 class FileCountSpec extends Specification with TestResources {
@@ -109,13 +109,13 @@ class FileCountSpec extends Specification with TestResources {
 
     "fail if an invalid relavtive basePath is given" in {
       wildCard.search( ("WRONGPATH/dri/fileCountTestFiles/threeFiles/","file1.jp2") ) must beLike {
-        case Failure(m) => m.list mustEqual List("""incorrect basepath WRONGPATH/dri/fileCountTestFiles/threeFiles/ (localfile: """ + TypedPath("WRONGPATH/dri/fileCountTestFiles/threeFiles/file1.jp2").toPlatform + """) found""")
+        case Failure(m) => m.list mustEqual IList("""incorrect basepath WRONGPATH/dri/fileCountTestFiles/threeFiles/ (localfile: """ + TypedPath("WRONGPATH/dri/fileCountTestFiles/threeFiles/file1.jp2").toPlatform + """) found""")
       }
     }
 
     "fail if invalid filename is given" in {
       wildCard.search( (threeFilesPath + FILE_SEPARATOR,"WRONG.WRONG") ) must beLike {
-        case Failure(m) => m.list mustEqual List("""file """" + threeFilesPath + FILE_SEPARATOR + """WRONG.WRONG" not found""")
+        case Failure(m) => m.list mustEqual IList("""file """" + threeFilesPath + FILE_SEPARATOR + """WRONG.WRONG" not found""")
       }
     }
 
@@ -176,19 +176,19 @@ class FileCountSpec extends Specification with TestResources {
 
     "fail if an invalid relative basePath is given" in {
       wildCard.search( ("WRONGPATH/dri/fileCountTestFiles/threeFiles/","file1.jp2") ) must beLike {
-        case Failure(m) => m.list mustEqual List("""incorrect basepath WRONGPATH/dri/fileCountTestFiles/threeFiles/ (localfile: """ + TypedPath("WRONGPATH/dri/fileCountTestFiles/threeFiles/file1.jp2").toPlatform + """) found""")
+        case Failure(m) => m.list mustEqual IList("""incorrect basepath WRONGPATH/dri/fileCountTestFiles/threeFiles/ (localfile: """ + TypedPath("WRONGPATH/dri/fileCountTestFiles/threeFiles/file1.jp2").toPlatform + """) found""")
       }
     }
 
     "fail if an invalid relative basePath is given" in {
       wildCard.search( ("src/test/dri/fileCountTestFiles/threeFiles/","xfile.jp2") ) must beLike {
-        case Failure(m) => m.list mustEqual List("""incorrect basepath src/test/dri/fileCountTestFiles/threeFiles/ (localfile: """ + TypedPath("src/test/dri/fileCountTestFiles/threeFiles/xfile.jp2").toPlatform + """) found""")
+        case Failure(m) => m.list mustEqual IList("""incorrect basepath src/test/dri/fileCountTestFiles/threeFiles/ (localfile: """ + TypedPath("src/test/dri/fileCountTestFiles/threeFiles/xfile.jp2").toPlatform + """) found""")
       }
     }
 
     "fail if invalid filename is given" in {
       wildCard.search( ("bob/fileCountTestFiles/threeFiles/","WRONG.WRONG") ) must beLike {
-        case Failure(m) => m.list mustEqual List("""file """" + Path.fromString(threeFilesPath).path + FILE_SEPARATOR + """WRONG.WRONG" not found""")
+        case Failure(m) => m.list mustEqual IList("""file """" + Path.fromString(threeFilesPath).path + FILE_SEPARATOR + """WRONG.WRONG" not found""")
       }
     }
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/FileExistsRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/FileExistsRuleSpec.scala
@@ -8,7 +8,9 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.{FILE_SEPARATOR, TestResources}
 import uk.gov.nationalarchives.csv.validator.Util.FileSystem
 import uk.gov.nationalarchives.csv.validator.api.CsvValidator.SubstitutePath
@@ -17,6 +19,7 @@ import uk.gov.nationalarchives.csv.validator.schema._
 
 import scalaz.{Failure, Success}
 
+@RunWith(classOf[JUnitRunner])
 class FileExistsRuleSpec extends Specification with TestResources {
 
   val relMustExistForRulePath = relResourcePath("mustExistForRule.csvs")

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/FileWildcardSearchSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/FileWildcardSearchSpec.scala
@@ -8,11 +8,14 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 
 import scalax.file.{Path, PathSet}
 import scalaz._
 
+@RunWith(classOf[JUnitRunner])
 class FileWildcardSearchSpec extends Specification {
 
   class FindBaseTestableFileWildcardSearch extends FileWildcardSearch[Int]{

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/IfRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/IfRuleSpec.scala
@@ -8,7 +8,9 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
@@ -18,6 +20,7 @@ import scalaz.{Failure, Success}
   * User: Jim Collins
   * Date: 3/7/13
   */
+@RunWith(classOf[JUnitRunner])
 class IfRuleSpec extends Specification {
 
   "IfRule" should  {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/InRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/InRuleSpec.scala
@@ -8,12 +8,15 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
 import scalaz.{Failure, Success}
 
+@RunWith(classOf[JUnitRunner])
 class InRuleSpec extends Specification {
 
   "InRule with a string literal behaviour" should  {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/LengthRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/LengthRuleSpec.scala
@@ -8,12 +8,15 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
 import scalaz.{Failure, Success}
 
+@RunWith(classOf[JUnitRunner])
 class LengthRuleSpec extends Specification {
 
   "Length rule" should  {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/LengthRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/LengthRuleSpec.scala
@@ -14,7 +14,7 @@ import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
-import scalaz.{Failure, Success}
+import scalaz.{Success, Failure, IList}
 
 @RunWith(classOf[JUnitRunner])
 class LengthRuleSpec extends Specification {
@@ -37,7 +37,7 @@ class LengthRuleSpec extends Specification {
       val lengthRule = new LengthRule(None, "5")
 
       lengthRule.evaluate(0, Row(List(Cell("HelloWorld")), 1), Schema(List(TotalColumns(1), NoHeader()), List(ColumnDefinition(NamedColumnIdentifier("column1"))))) must beLike {
-        case Failure(m) => m.list mustEqual List("""length(5) fails for line: 1, column: column1, value: "HelloWorld"""")
+        case Failure(m) => m.list mustEqual IList("""length(5) fails for line: 1, column: column1, value: "HelloWorld"""")
       }
     }
 
@@ -57,7 +57,7 @@ class LengthRuleSpec extends Specification {
       val lengthRule = new LengthRule(Some("1"), "5")
 
       lengthRule.evaluate(0, Row(List(Cell("helloworld")), 1), Schema(List(TotalColumns(1), NoHeader()), List(ColumnDefinition(NamedColumnIdentifier("column1"))))) must beLike {
-        case Failure(m) => m.list mustEqual List("""length(1,5) fails for line: 1, column: column1, value: "helloworld"""")
+        case Failure(m) => m.list mustEqual IList("""length(1,5) fails for line: 1, column: column1, value: "helloworld"""")
       }
     }
 
@@ -84,7 +84,7 @@ class LengthRuleSpec extends Specification {
       val lengthRule = new LengthRule(Some("5"), "5")
 
       lengthRule.evaluate(0, Row(List(Cell("helloworld")), 1), Schema(List(TotalColumns(1), NoHeader()), List(ColumnDefinition(NamedColumnIdentifier("column1"))))) must beLike {
-        case Failure(m) => m.list mustEqual List("""length(5,5) fails for line: 1, column: column1, value: "helloworld"""")
+        case Failure(m) => m.list mustEqual IList("""length(5,5) fails for line: 1, column: column1, value: "helloworld"""")
       }
     }
 
@@ -111,7 +111,7 @@ class LengthRuleSpec extends Specification {
       val lengthRule = new LengthRule(None, "43")
 
       lengthRule.evaluate(0, Row(List(Cell("helloworld")), 1), Schema(List(TotalColumns(1), NoHeader()), List(ColumnDefinition(NamedColumnIdentifier("column1"))))) must beLike {
-        case Failure(m) => m.list mustEqual List("""length(43) fails for line: 1, column: column1, value: "helloworld"""")
+        case Failure(m) => m.list mustEqual IList("""length(43) fails for line: 1, column: column1, value: "helloworld"""")
       }
     }
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/NoArgRulesSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/NoArgRulesSpec.scala
@@ -8,7 +8,9 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema.{ColumnDefinition, NamedColumnIdentifier, Schema, TotalColumns}
 
@@ -18,6 +20,7 @@ import scalaz.{Failure, Success}
  * User: Jim Collins
  * Date: 2/20/13
  */
+@RunWith(classOf[JUnitRunner])
 class NoArgRulesSpec extends Specification {
 
   val globalDirsOne = List(TotalColumns(1))

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/NotEmptyRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/NotEmptyRuleSpec.scala
@@ -8,12 +8,15 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema.{ColumnDefinition, NamedColumnIdentifier, Schema, TotalColumns}
 
 import scalaz.{Failure, Success}
 
+@RunWith(classOf[JUnitRunner])
 class NotEmptyRuleSpec extends Specification {
 
    val globalDirsOne = List(TotalColumns(1))

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/OrRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/OrRuleSpec.scala
@@ -8,12 +8,15 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
 import scalaz.{Failure, Success}
 
+@RunWith(classOf[JUnitRunner])
 class OrRuleSpec extends Specification {
 
   "OrRule" should {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/OrRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/OrRuleSpec.scala
@@ -14,7 +14,7 @@ import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
-import scalaz.{Failure, Success}
+import scalaz.{Success, Failure, IList}
 
 @RunWith(classOf[JUnitRunner])
 class OrRuleSpec extends Specification {
@@ -54,7 +54,7 @@ class OrRuleSpec extends Specification {
       val orRule = OrRule(leftInRule, rightInRule)
 
       orRule.evaluate(0, Row(List(Cell("SomethingElse")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("""in("This") or in("That") fails for line: 1, column: ThisOrThat, value: "SomethingElse"""")
+        case Failure(messages) => messages.list mustEqual IList("""in("This") or in("That") fails for line: 1, column: ThisOrThat, value: "SomethingElse"""")
       }
     }
 
@@ -107,7 +107,7 @@ class OrRuleSpec extends Specification {
       val orRule =  OrRule( OrRule(leftInRule, middleInRule), rightInRule )
 
       orRule.evaluate(0, Row(List(Cell("up")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("""in("left") or in("middle") or in("right") fails for line: 1, column: Direction, value: "up"""")
+        case Failure(messages) => messages.list mustEqual IList("""in("left") or in("middle") or in("right") fails for line: 1, column: Direction, value: "up"""")
       }
     }
   }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/RangeRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/RangeRuleSpec.scala
@@ -12,8 +12,8 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
-import scalaz.{Success, Failure}
 import uk.gov.nationalarchives.csv.validator.schema._
+import scalaz.{Success, Failure, IList}
 
 @RunWith(classOf[JUnitRunner])
 class RangeRuleSpec extends Specification {
@@ -26,7 +26,7 @@ class RangeRuleSpec extends Specification {
       val rangeRule = new RangeRule(1,2)
 
       rangeRule.evaluate(0, Row(List(Cell("Germany")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("""range(1,2) fails for line: 1, column: Country, value: "Germany"""")
+        case Failure(messages) => messages.list mustEqual IList("""range(1,2) fails for line: 1, column: Country, value: "Germany"""")
       }
     }
 
@@ -40,7 +40,7 @@ class RangeRuleSpec extends Specification {
       val rangeRule = new RangeRule(0.01,0.1)
 
       rangeRule.evaluate(0, Row(List(Cell(("0.00999999999999999999999999999999"))), 1), schema)  must beLike {
-        case Failure(messages) => messages.list mustEqual List("""range(0.01,0.1) fails for line: 1, column: Country, value: "0.00999999999999999999999999999999"""")
+        case Failure(messages) => messages.list mustEqual IList("""range(0.01,0.1) fails for line: 1, column: Country, value: "0.00999999999999999999999999999999"""")
       }
     }
   }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/RangeRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/RangeRuleSpec.scala
@@ -8,13 +8,14 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import scalaz.{Success, Failure}
 import uk.gov.nationalarchives.csv.validator.schema._
 
-
-
+@RunWith(classOf[JUnitRunner])
 class RangeRuleSpec extends Specification {
 
   "RangeRule" should  {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserColumnDefinitionsSpecs.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserColumnDefinitionsSpecs.scala
@@ -11,12 +11,12 @@ package uk.gov.nationalarchives.csv.validator.schema.v1_0
 import java.io.StringReader
 
 
-import uk.gov.nationalarchives.csv.validator.SchemaMessage
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
+import uk.gov.nationalarchives.csv.validator.{SchemaDefinitionError, FailMessage}
 import uk.gov.nationalarchives.csv.validator.schema._
 
-import scalaz.{Failure => FailureZ, Success => SuccessZ}
+import scalaz.{Failure => FailureZ, Success => SuccessZ, IList}
 
 @RunWith(classOf[JUnitRunner])
 class SchemaParserColumnDefinitionsSpecs extends SchemaSpecBase {
@@ -87,7 +87,7 @@ class SchemaParserColumnDefinitionsSpecs extends SchemaSpecBase {
                       |@totalColumns 2
                       |LastName: regex ("[a]")""".stripMargin
 
-      parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("@totalColumns = 2 but number of columns defined = 1 at line: 2, column: 1")) }
+      parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "@totalColumns = 2 but number of columns defined = 1 at line: 2, column: 1")) }
     }
 
     "fail for invalid column identifier" in {
@@ -139,7 +139,7 @@ class SchemaParserColumnDefinitionsSpecs extends SchemaSpecBase {
                     |Column2:""".stripMargin
 
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: Column1 has invalid cross reference in($NotAColumn) at line: 3, column: 10"))
+        case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Column1 has invalid cross reference in($NotAColumn) at line: 3, column: 10"))
       }
     }
 
@@ -150,7 +150,7 @@ class SchemaParserColumnDefinitionsSpecs extends SchemaSpecBase {
                     |Column2:""".stripMargin
 
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: Column1 has invalid cross reference in($NotAColumn2) at line: 3, column: 23"))
+        case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Column1 has invalid cross reference in($NotAColumn2) at line: 3, column: 23"))
       }
     }
 
@@ -161,7 +161,7 @@ class SchemaParserColumnDefinitionsSpecs extends SchemaSpecBase {
                     |Column2: in($NotAColumn3) in($Column2)""".stripMargin
 
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage(
+        case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError,
           """Column: Column1 has invalid cross reference in($NotAColumn2) at line: 3, column: 23
             |Column: Column2 has invalid cross reference in($NotAColumn3) at line: 4, column: 10""".stripMargin))
       }
@@ -177,7 +177,7 @@ class SchemaParserColumnDefinitionsSpecs extends SchemaSpecBase {
                     |Column5: ends($Column5) ends($NotAColumn5)""".stripMargin
 
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("""@totalColumns = 2 but number of columns defined = 5 at line: 2, column: 1
+        case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, """@totalColumns = 2 but number of columns defined = 5 at line: 2, column: 1
                                                         |Column: Column1 has invalid cross reference is($NotAColumn1) at line: 3, column: 23
                                                         |Column: Column2 has invalid cross reference not($NotAColumn2) at line: 4, column: 24
                                                         |Column: Column3 has invalid cross reference in($NotAColumn3) at line: 5, column: 23
@@ -195,7 +195,7 @@ class SchemaParserColumnDefinitionsSpecs extends SchemaSpecBase {
                       Column2:"""
 
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("""Column: Column1 has duplicates on lines 3, 5
+        case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: Column1 has duplicates on lines 3, 5
                                                           |Column: Column2 has duplicates on lines 4, 6""".stripMargin))
       }
     }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserColumnDefinitionsSpecs.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserColumnDefinitionsSpecs.scala
@@ -12,10 +12,13 @@ import java.io.StringReader
 
 
 import uk.gov.nationalarchives.csv.validator.SchemaMessage
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.schema._
 
 import scalaz.{Failure => FailureZ, Success => SuccessZ}
 
+@RunWith(classOf[JUnitRunner])
 class SchemaParserColumnDefinitionsSpecs extends SchemaSpecBase {
 
   import TestSchemaParser._

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserColumnDirectivesSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserColumnDirectivesSpec.scala
@@ -11,10 +11,13 @@ package uk.gov.nationalarchives.csv.validator.schema.v1_0
 import java.io.StringReader
 
 import uk.gov.nationalarchives.csv.validator.SchemaMessage
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.schema._
 
 import scalaz.{Failure => FailureZ}
 
+@RunWith(classOf[JUnitRunner])
 class SchemaParserColumnDirectivesSpec extends SchemaSpecBase {
 
   import TestSchemaParser._

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserColumnDirectivesSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserColumnDirectivesSpec.scala
@@ -10,12 +10,12 @@ package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
 import java.io.StringReader
 
-import uk.gov.nationalarchives.csv.validator.SchemaMessage
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
+import uk.gov.nationalarchives.csv.validator.{SchemaDefinitionError, FailMessage}
 import uk.gov.nationalarchives.csv.validator.schema._
 
-import scalaz.{Failure => FailureZ}
+import scalaz.{Failure => FailureZ, IList}
 
 @RunWith(classOf[JUnitRunner])
 class SchemaParserColumnDirectivesSpec extends SchemaSpecBase {
@@ -45,7 +45,7 @@ class SchemaParserColumnDirectivesSpec extends SchemaSpecBase {
                      |@totalColumns 1
                      |column1: @ignoreCase @ignoreCase""".stripMargin
 
-      parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage(
+      parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError,
         """[3.23] failure: `warning' expected but `i' found
         |
         |column1: @ignoreCase @ignoreCase
@@ -57,7 +57,7 @@ class SchemaParserColumnDirectivesSpec extends SchemaSpecBase {
                      |@totalColumns 1
                      |column1: @ignoreCase @optional @ignoreCase @optional""".stripMargin
 
-      parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage(
+      parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError,
        """[3.33] failure: `warning' expected but `i' found
        |
        |column1: @ignoreCase @optional @ignoreCase @optional
@@ -71,7 +71,7 @@ class SchemaParserColumnDirectivesSpec extends SchemaSpecBase {
                      |column2: @optional @ignoreCase
                      |column3: @ignoreCase @ignoreCase @optional @optional""".stripMargin
 
-      parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage(
+      parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError,
         """[3.33] failure: `warning' expected but `i' found
           |
           |column1: @ignoreCase @optional @ignoreCase @optional

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserGlobalDirectivesSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserGlobalDirectivesSpec.scala
@@ -10,9 +10,11 @@ package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
 import java.io.StringReader
 
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.schema._
 
-
+@RunWith(classOf[JUnitRunner])
 class SchemaParserGlobalDirectivesSpec extends SchemaSpecBase {
 
   import TestSchemaParser._

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserGlobalDirectivesSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserGlobalDirectivesSpec.scala
@@ -52,7 +52,7 @@ class SchemaParserGlobalDirectivesSpec extends SchemaSpecBase {
     }
 
     "@noHeader and @ignoreColumnNameCase global directives (mutually exclusive)" should {
-      "fail for @noHeader followed by @ignoreColumnNameCase" >> pending("Need to improve error messages") {
+      "fail for @noHeader followed by @ignoreColumnNameCase" in {
         val schema =
           """version 1.0
             |@noHeader
@@ -60,9 +60,9 @@ class SchemaParserGlobalDirectivesSpec extends SchemaSpecBase {
             |column1: """.stripMargin
 
         parse(new StringReader(schema)) must beLike { case Failure(message, _) => message mustEqual "Invalid global directive" }
-      }
+      }.pendingUntilFixed("Need to improve error messages")
 
-      "fail for @ignoreColumnNameCase followed by @noHeader" >> pending("Need to improve error messages") {
+      "fail for @ignoreColumnNameCase followed by @noHeader" in {
         val schema =
           """version 1.0
             |@ignoreColumnNameCase
@@ -70,7 +70,7 @@ class SchemaParserGlobalDirectivesSpec extends SchemaSpecBase {
             |column1: """.stripMargin
 
         parse(new StringReader(schema)) must beLike { case Failure(message, _) => message mustEqual "Invalid global directive" }
-      }
+      }.pendingUntilFixed("Need to improve error messages")
     }
 
     "succeed with no global directives" in {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserRulesSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserRulesSpec.scala
@@ -12,11 +12,11 @@ import java.io.StringReader
 
 import org.junit.runner.RunWith
 import org.specs2.mutable._
-import uk.gov.nationalarchives.csv.validator.{EOL, SchemaMessage}
 import org.specs2.runner.JUnitRunner
+import uk.gov.nationalarchives.csv.validator.{SchemaDefinitionError, FailMessage, EOL}
 import uk.gov.nationalarchives.csv.validator.schema._
 
-import scalaz.{Failure => FailureZ, Success => SuccessZ}
+import scalaz.{Failure => FailureZ, Success => SuccessZ, IList}
 
 @RunWith(classOf[JUnitRunner])
 class SchemaParserRulesSpec extends SchemaSpecBase {
@@ -41,7 +41,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                       Something: regex("[0-9")"""
 
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: Something: Invalid regex(\"[0-9\"): at line: 3, column: 34"))
+        case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Something: Invalid regex(\"[0-9\"): at line: 3, column: 34"))
       }
     }
 
@@ -212,7 +212,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
         """
 
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("""Column: MD5: Invalid Algorithm: 'INVALID' at line: 4, column: 17"""))
+        case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: MD5: Invalid Algorithm: 'INVALID' at line: 4, column: 17"""))
       }
     }
 
@@ -226,7 +226,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
         """
 
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: MD5: Invalid Algorithm: 'INVALID' at line: 4, column: 17" + EOL + "Column: chksum: Invalid Algorithm: 'WRONG' at line: 5, column: 20"))
+        case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: MD5: Invalid Algorithm: 'INVALID' at line: 4, column: 17" + EOL + "Column: chksum: Invalid Algorithm: 'WRONG' at line: 5, column: 20"))
       }
     }
 
@@ -240,7 +240,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
         """
 
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("""Column: MD5: Invalid Algorithm: 'INVALID' at line: 4, column: 17"""))
+        case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: MD5: Invalid Algorithm: 'INVALID' at line: 4, column: 17"""))
       }
     }
 
@@ -263,7 +263,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
            @totalColumns 1
            Country: xDateTime( 2012-99-01T01:01:01 , 2012-12-01T01:01:01 )"""
 
-    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: Country: Invalid xDateTime(\"2012-99-01T01:01:01, 2012-12-01T01:01:01\"): at line: 3, column: 21")) }
+    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Country: Invalid xDateTime(\"2012-99-01T01:01:01, 2012-12-01T01:01:01\"): at line: 3, column: 21")) }
   }
 
   "fail for xDateTime range with from > to" in {
@@ -272,7 +272,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
            @totalColumns 1
            Country: xDateTime( 2012-01-02T01:01:02 , 2012-01-01T01:01:02 )"""
 
-    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: Country: Invalid xDateTime(\"2012-01-02T01:01:02, 2012-01-01T01:01:02\"): at line: 3, column: 21")) }
+    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Country: Invalid xDateTime(\"2012-01-02T01:01:02, 2012-01-01T01:01:02\"): at line: 3, column: 21")) }
   }
 
 
@@ -293,7 +293,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
            @totalColumns 1
            Country: xDate( 2012-99-01 , 2012-12-01 )"""
 
-    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: Country: Invalid xDate(\"2012-99-01, 2012-12-01\"): at line: 3, column: 21")) }
+    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Country: Invalid xDate(\"2012-99-01, 2012-12-01\"): at line: 3, column: 21")) }
   }
 
   "fail for xDate range with from > to" in {
@@ -302,7 +302,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
            @totalColumns 1
            Country: xDate( 2012-01-02 , 2012-01-01 )"""
 
-    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: Country: Invalid xDate(\"2012-01-02, 2012-01-01\"): at line: 3, column: 21")) }
+    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Country: Invalid xDate(\"2012-01-02, 2012-01-01\"): at line: 3, column: 21")) }
   }
 
   "succeed for ukDate range with valid date" in {
@@ -322,7 +322,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
            @totalColumns 1
            Country: ukDate( 30/02/1900 , 30/02/1902 )"""
 
-    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: Country: Invalid ukDate(\"30/02/1900, 30/02/1902\"): at line: 3, column: 21")) }
+    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Country: Invalid ukDate(\"30/02/1900, 30/02/1902\"): at line: 3, column: 21")) }
   }
 
   "fail for ukDate range with from > to" in {
@@ -331,7 +331,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
            @totalColumns 1
            Country: ukDate( 02/02/1966 , 01/02/1966 )"""
 
-    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: Country: Invalid ukDate(\"02/02/1966, 01/02/1966\"): at line: 3, column: 21")) }
+    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Country: Invalid ukDate(\"02/02/1966, 01/02/1966\"): at line: 3, column: 21")) }
   }
 
   "succeed for xTime range with valid time" in {
@@ -351,7 +351,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
            @totalColumns 1
            Country: xTime( 90:10:20 , 10:12:22 )"""
 
-    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: Country: Invalid xTime(\"90:10:20, 10:12:22\"): at line: 3, column: 21")) }
+    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Country: Invalid xTime(\"90:10:20, 10:12:22\"): at line: 3, column: 21")) }
   }
 
   "fail for xTime range with from > to" in {
@@ -360,7 +360,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
            @totalColumns 1
            Country: xTime( 00:10:21 , 00:10:20 )"""
 
-    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: Country: Invalid xTime(\"00:10:21, 00:10:20\"): at line: 3, column: 21")) }
+    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Country: Invalid xTime(\"00:10:21, 00:10:20\"): at line: 3, column: 21")) }
   }
 
   "succeed for multiple date ranges with valid dates" in {
@@ -380,7 +380,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
            @totalColumns 1
            Country: xTime( 99:10:20 , 00:10:20 ) ukDate( 01/02/1966 , 31/02/1966 ) xDateTime( 2012-13-01T01:01:01 , 2012-12-01T01:01:01 ) xDate( 2012-12-40 , 2012-12-01 )"""
 
-    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage(
+    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError,
       """Column: Country: Invalid xTime("99:10:20, 00:10:20"): at line: 3, column: 21
         |Column: Country: Invalid ukDate("01/02/1966, 31/02/1966"): at line: 3, column: 50
         |Column: Country: Invalid xDateTime("2012-13-01T01:01:01, 2012-12-01T01:01:01"): at line: 3, column: 84
@@ -457,7 +457,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                    |Country: is($MyMissingCountry)
                    |MyCountry:""".stripMargin
 
-    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: Country has invalid cross reference is($MyMissingCountry) at line: 3, column: 10")) }
+    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Country has invalid cross reference is($MyMissingCountry) at line: 3, column: 10")) }
   }
 
   "fail for invalid regex rule and'is' cross reference rule" in {
@@ -466,7 +466,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                    |MyCountry: regex("[a-z*")
                    |Country: is($MyMissingCountry)""".stripMargin
 
-    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage(
+    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError,
       """Column: Country has invalid cross reference is($MyMissingCountry) at line: 4, column: 10
         |Column: MyCountry: Invalid regex("[a-z*"): at line: 3, column: 12""".stripMargin)) }
   }
@@ -505,7 +505,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                    |Country: not($MyMissingCountry)
                    |MyCountry:""".stripMargin
 
-    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: Country has invalid cross reference not($MyMissingCountry) at line: 3, column: 10")) }
+    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Country has invalid cross reference not($MyMissingCountry) at line: 3, column: 10")) }
   }
 
   "succeed for 'starts' text rule" in {
@@ -537,7 +537,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                    |Country: starts($MyMissingCountry)
                    |MyCountry:""".stripMargin
 
-    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("Column: Country has invalid cross reference starts($MyMissingCountry) at line: 3, column: 10")) }
+    parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Country has invalid cross reference starts($MyMissingCountry) at line: 3, column: 10")) }
   }
 
   "succeed for 'ends' text rule" in {
@@ -568,7 +568,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                    |MyCountry:""".stripMargin
 
     parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) =>
-      msgs.list mustEqual List(SchemaMessage("Column: Country has invalid cross reference ends($MyMissingCountry) at line: 3, column: 10")) }
+      msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, "Column: Country has invalid cross reference ends($MyMissingCountry) at line: 3, column: 10")) }
   }
 
   "succeed for multiple nested parens" in {
@@ -602,7 +602,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
            MD5: checksum(file($Root, $WRONG), "MD5")
         """
 
-      parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("""Column: MD5 has invalid cross reference checksum(file($Root, $WRONG), "MD5") at line: 5, column: 17""")) }
+      parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: MD5 has invalid cross reference checksum(file($Root, $WRONG), "MD5") at line: 5, column: 17""")) }
     }
 
     "fail if column for basePath is missing" in {
@@ -614,7 +614,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
            MD5: checksum(file($Hello, $File), "MD5")
         """
 
-      parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("""Column: MD5 has invalid cross reference checksum(file($Hello, $File), "MD5") at line: 5, column: 17""")) }
+      parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: MD5 has invalid cross reference checksum(file($Hello, $File), "MD5") at line: 5, column: 17""")) }
     }
   }
 
@@ -647,7 +647,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                       MyCountry:"""
 
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(msgs) => msgs.list mustEqual List(SchemaMessage("""Column: Age: Invalid range, minimum greater than maximum in: 'range(100,1)' at line: 3, column: 28"""))
+        case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: Age: Invalid range, minimum greater than maximum in: 'range(100,1)' at line: 3, column: 28"""))
       }
     }
   }
@@ -741,7 +741,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                       Age: length(100,1)"""
 
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(messages) => messages.list mustEqual List(SchemaMessage("""Column: Age: Invalid length, minimum greater than maximum in: 'length(100,1)' at line: 3, column: 28"""))
+        case FailureZ(messages) => messages.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: Age: Invalid length, minimum greater than maximum in: 'length(100,1)' at line: 3, column: 28"""))
       }
 
     }
@@ -844,7 +844,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                       PostCode:
                    """
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(messages) => messages.list mustEqual List(SchemaMessage("""Column: Name: Invalid cross reference $MADEUP: at line: 3, column: 29"""))
+        case FailureZ(messages) => messages.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: Name: Invalid cross reference $MADEUP: at line: 3, column: 29"""))
       }
     }
   }
@@ -870,7 +870,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                       LastName: $WRONGCOLUMN/is("Yoda")
                    """
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(messages) => messages.list mustEqual List(SchemaMessage("""Column: LastName: Invalid explicit column WRONGCOLUMN: at line: 4, column: 33"""))
+        case FailureZ(messages) => messages.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: LastName: Invalid explicit column WRONGCOLUMN: at line: 4, column: 33"""))
       }
     }
 
@@ -881,7 +881,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                       LastName: if( $WRONGCOLUMN/is("Yoda"), is(""))
                    """
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(messages) => messages.list mustEqual List(SchemaMessage("""Column: LastName: Invalid explicit column WRONGCOLUMN: at line: 4, column: 33"""))
+        case FailureZ(messages) => messages.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: LastName: Invalid explicit column WRONGCOLUMN: at line: 4, column: 33"""))
       }
     }
 
@@ -892,7 +892,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                       LastName: if( is("Yoda"), $WRONGCOLUMN/is(""))
                    """
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(messages) => messages.list mustEqual List(SchemaMessage("""Column: LastName: Invalid explicit column WRONGCOLUMN: at line: 4, column: 33"""))
+        case FailureZ(messages) => messages.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: LastName: Invalid explicit column WRONGCOLUMN: at line: 4, column: 33"""))
       }
     }
 
@@ -903,7 +903,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                       LastName: if( is("Yoda"), is(""), $WRONGCOLUMN/is(""))
                    """
       parseAndValidate(new StringReader(schema)) must beLike {
-        case FailureZ(messages) => messages.list mustEqual List(SchemaMessage("""Column: LastName: Invalid explicit column WRONGCOLUMN: at line: 4, column: 33"""))
+        case FailureZ(messages) => messages.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: LastName: Invalid explicit column WRONGCOLUMN: at line: 4, column: 33"""))
       }
     }
   }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserRulesSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserRulesSpec.scala
@@ -10,12 +10,15 @@ package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
 import java.io.StringReader
 
+import org.junit.runner.RunWith
 import org.specs2.mutable._
 import uk.gov.nationalarchives.csv.validator.{EOL, SchemaMessage}
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.schema._
 
 import scalaz.{Failure => FailureZ, Success => SuccessZ}
 
+@RunWith(classOf[JUnitRunner])
 class SchemaParserRulesSpec extends SchemaSpecBase {
 
   val emptyPathSubstitutions = List[(String,String)]()

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserSpecs.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserSpecs.scala
@@ -9,8 +9,11 @@
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
 import java.io.StringReader
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.schema._
 
+@RunWith(classOf[JUnitRunner])
 class SchemaParserSpecs extends SchemaSpecBase {
 
   import TestSchemaParser._

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserTotalColumnsSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserTotalColumnsSpec.scala
@@ -10,8 +10,11 @@ package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
 import java.io.StringReader
 
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.schema._
 
+@RunWith(classOf[JUnitRunner])
 class SchemaParserTotalColumnsSpec extends SchemaSpecBase {
 
   import TestSchemaParser._

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/UniqueMultiRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/UniqueMultiRuleSpec.scala
@@ -14,7 +14,7 @@ import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
-import scalaz.{Failure, Success}
+import scalaz.{Failure, Success, IList}
 
 @RunWith(classOf[JUnitRunner])
 class UniqueMultiRuleSpec extends Specification {
@@ -43,7 +43,7 @@ class UniqueMultiRuleSpec extends Specification {
 
       rule.evaluate(0, Row(Cell("r2d2") :: Cell("3") :: Cell("blue") :: Nil, 1), schema)
       rule.evaluate(0, Row(Cell("r2d2") :: Cell("3") :: Cell("blue") :: Nil, 2), schema) must beLike {
-        case Failure(msgs) => msgs.list mustEqual(List("unique( $Legs, $Color ) fails for line: 2, column: Name, value: \"r2d2\" (original at line: 1)"))
+        case Failure(msgs) => msgs.list mustEqual IList("unique( $Legs, $Color ) fails for line: 2, column: Name, value: \"r2d2\" (original at line: 1)")
       }
     }
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/UniqueMultiRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/UniqueMultiRuleSpec.scala
@@ -8,12 +8,15 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
 import scalaz.{Failure, Success}
 
+@RunWith(classOf[JUnitRunner])
 class UniqueMultiRuleSpec extends Specification {
 
   "unique multi rule" should {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/UniqueRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/UniqueRuleSpec.scala
@@ -8,12 +8,15 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_0
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
 import scalaz.{Failure, Success}
 
+@RunWith(classOf[JUnitRunner])
 class UniqueRuleSpec extends Specification {
 
   "unique rule" should {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/UniqueRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/UniqueRuleSpec.scala
@@ -14,7 +14,7 @@ import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
-import scalaz.{Failure, Success}
+import scalaz.{Failure, Success, IList}
 
 @RunWith(classOf[JUnitRunner])
 class UniqueRuleSpec extends Specification {
@@ -37,7 +37,7 @@ class UniqueRuleSpec extends Specification {
       rule.evaluate(0, Row(Cell("Ben") :: Nil, 2), schema)
 
       rule.evaluate(0, Row(Cell("Jim") :: Nil, 3), schema) must beLike {
-        case Failure(msgs) => msgs.list mustEqual(List("unique fails for line: 3, column: Name, value: \"Jim\" (original at line: 1)"))
+        case Failure(msgs) => msgs.list mustEqual IList("unique fails for line: 3, column: Name, value: \"Jim\" (original at line: 1)")
       }
     }
 
@@ -48,7 +48,7 @@ class UniqueRuleSpec extends Specification {
       rule.evaluate(0, Row(Cell("Ben") :: Nil, 1), schema)
 
       rule.evaluate(0, Row(Cell("BEN") :: Nil, 2), schema) must beLike {
-        case Failure(msgs) => msgs.list mustEqual(List("unique fails for line: 2, column: Name, value: \"BEN\" (original at line: 1)"))
+        case Failure(msgs) => msgs.list mustEqual IList("unique fails for line: 2, column: Name, value: \"BEN\" (original at line: 1)")
       }
     }
   }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/AnyRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/AnyRuleSpec.scala
@@ -8,12 +8,15 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_1
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 
 import scalaz.{Failure, Success}
 
+@RunWith(classOf[JUnitRunner])
 class AnyRuleSpec extends Specification {
 
   "AnyRule with a string literal behaviour" should  {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/CaseRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/CaseRuleSpec.scala
@@ -8,12 +8,15 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_1
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema.{ColumnDefinition, NamedColumnIdentifier, Schema, TotalColumns}
 
 import scalaz.{Failure, Success}
 
+@RunWith(classOf[JUnitRunner])
 class CaseRuleSpec extends Specification {
 
   "UpperCaseRule" should {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/CaseRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/CaseRuleSpec.scala
@@ -14,7 +14,7 @@ import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema.{ColumnDefinition, NamedColumnIdentifier, Schema, TotalColumns}
 
-import scalaz.{Failure, Success}
+import scalaz.{Success, Failure, IList}
 
 @RunWith(classOf[JUnitRunner])
 class CaseRuleSpec extends Specification {
@@ -87,7 +87,7 @@ class CaseRuleSpec extends Specification {
 
 
       upperCaseRule.evaluate(0, Row(List(Cell("germany")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 1, column: Country, value: \"germany\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 1, column: Country, value: \"germany\"")
       }
 
     }
@@ -102,13 +102,13 @@ class CaseRuleSpec extends Specification {
 
 
       upperCaseRule.evaluate(0, Row(List(Cell("GeRMANY")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 1, column: Country, value: \"GeRMANY\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 1, column: Country, value: \"GeRMANY\"")
       }
       upperCaseRule.evaluate(0, Row(List(Cell("GeRmANy")), 2), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 2, column: Country, value: \"GeRmANy\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 2, column: Country, value: \"GeRmANy\"")
       }
       upperCaseRule.evaluate(0, Row(List(Cell("gERMANY")), 3), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 3, column: Country, value: \"gERMANY\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 3, column: Country, value: \"gERMANY\"")
       }
 
     }
@@ -122,13 +122,13 @@ class CaseRuleSpec extends Specification {
 
 
       upperCaseRule.evaluate(0, Row(List(Cell("ΑρΣΕΝΑΛ")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 1, column: Country, value: \"ΑρΣΕΝΑΛ\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 1, column: Country, value: \"ΑρΣΕΝΑΛ\"")
       }
       upperCaseRule.evaluate(0, Row(List(Cell("ΑρΣεΝΑΛ")), 2), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 2, column: Country, value: \"ΑρΣεΝΑΛ\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 2, column: Country, value: \"ΑρΣεΝΑΛ\"")
       }
       upperCaseRule.evaluate(0, Row(List(Cell("αΡΣΕΝΑΛ")), 3), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 3, column: Country, value: \"αΡΣΕΝΑΛ\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 3, column: Country, value: \"αΡΣΕΝΑΛ\"")
       }
 
     }
@@ -142,10 +142,10 @@ class CaseRuleSpec extends Specification {
       val upperCaseRule = UpperCaseRule()
 
       upperCaseRule.evaluate(0, Row(List(Cell("United Kingdom")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 1, column: Country, value: \"United Kingdom\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 1, column: Country, value: \"United Kingdom\"")
       }
       upperCaseRule.evaluate(0, Row(List(Cell("uNITED KINGDOM")), 2), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 2, column: Country, value: \"uNITED KINGDOM\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 2, column: Country, value: \"uNITED KINGDOM\"")
       }
     }
 
@@ -157,10 +157,10 @@ class CaseRuleSpec extends Specification {
       val upperCaseRule = UpperCaseRule()
 
       upperCaseRule.evaluate(0, Row(List(Cell("United Kingdom 11111")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 1, column: Country, value: \"United Kingdom 11111\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 1, column: Country, value: \"United Kingdom 11111\"")
       }
       upperCaseRule.evaluate(0, Row(List(Cell("uNITED KINGDOM 12345")), 2), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 2, column: Country, value: \"uNITED KINGDOM 12345\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 2, column: Country, value: \"uNITED KINGDOM 12345\"")
       }
     }
 
@@ -172,10 +172,10 @@ class CaseRuleSpec extends Specification {
       val upperCaseRule = UpperCaseRule()
 
       upperCaseRule.evaluate(0, Row(List(Cell("United Kingdom 11111 ??")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 1, column: Country, value: \"United Kingdom 11111 ??\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 1, column: Country, value: \"United Kingdom 11111 ??\"")
       }
       upperCaseRule.evaluate(0, Row(List(Cell("uNITED KINGDOM 12345 ?!\"£")), 2), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 2, column: Country, value: \"uNITED KINGDOM 12345 ?!\"£\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 2, column: Country, value: \"uNITED KINGDOM 12345 ?!\"£\"")
       }
     }
     
@@ -210,15 +210,15 @@ class CaseRuleSpec extends Specification {
       val lowerCaseRule = LowerCaseRule()
       
       lowerCaseRule.evaluate(0, Row(List(Cell("GERMANY")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("lowerCase fails for line: 1, column: Country, value: \"GERMANY\"")
+        case Failure(messages) => messages.list mustEqual IList("lowerCase fails for line: 1, column: Country, value: \"GERMANY\"")
       }
 
       lowerCaseRule.evaluate(0, Row(List(Cell("GeRMaNy")), 2), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("lowerCase fails for line: 2, column: Country, value: \"GeRMaNy\"")
+        case Failure(messages) => messages.list mustEqual IList("lowerCase fails for line: 2, column: Country, value: \"GeRMaNy\"")
       }
 
       lowerCaseRule.evaluate(0, Row(List(Cell("Germany")), 3), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("lowerCase fails for line: 3, column: Country, value: \"Germany\"")
+        case Failure(messages) => messages.list mustEqual IList("lowerCase fails for line: 3, column: Country, value: \"Germany\"")
       }
     }
 
@@ -229,13 +229,13 @@ class CaseRuleSpec extends Specification {
       val lowerCaseRule = LowerCaseRule()
 
       lowerCaseRule.evaluate(0, Row(List(Cell("ΑρΣΕΝΑΛ")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("lowerCase fails for line: 1, column: Country, value: \"ΑρΣΕΝΑΛ\"")
+        case Failure(messages) => messages.list mustEqual IList("lowerCase fails for line: 1, column: Country, value: \"ΑρΣΕΝΑΛ\"")
       }
       lowerCaseRule.evaluate(0, Row(List(Cell("ΑρΣεΝΑΛ")), 2), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("lowerCase fails for line: 2, column: Country, value: \"ΑρΣεΝΑΛ\"")
+        case Failure(messages) => messages.list mustEqual IList("lowerCase fails for line: 2, column: Country, value: \"ΑρΣεΝΑΛ\"")
       }
       lowerCaseRule.evaluate(0, Row(List(Cell("αΡΣΕΝΑΛ")), 3), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("lowerCase fails for line: 3, column: Country, value: \"αΡΣΕΝΑΛ\"")
+        case Failure(messages) => messages.list mustEqual IList("lowerCase fails for line: 3, column: Country, value: \"αΡΣΕΝΑΛ\"")
       }
     }
 
@@ -255,7 +255,7 @@ class CaseRuleSpec extends Specification {
 
       val lowerCaseRule = LowerCaseRule()
       lowerCaseRule.evaluate(0, Row(List(Cell("United Kingdom")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("lowerCase fails for line: 1, column: Country, value: \"United Kingdom\"")
+        case Failure(messages) => messages.list mustEqual IList("lowerCase fails for line: 1, column: Country, value: \"United Kingdom\"")
       }
     }
 
@@ -277,7 +277,7 @@ class CaseRuleSpec extends Specification {
 
       val lowerCaseRule = LowerCaseRule()
       lowerCaseRule.evaluate(0, Row(List(Cell("united Kingdom 1234569")), 1), schema)must beLike {
-        case Failure(messages) => messages.list mustEqual List("lowerCase fails for line: 1, column: Country, value: \"united Kingdom 1234569\"")
+        case Failure(messages) => messages.list mustEqual IList("lowerCase fails for line: 1, column: Country, value: \"united Kingdom 1234569\"")
       }
     }
 
@@ -300,7 +300,7 @@ class CaseRuleSpec extends Specification {
 
 
       upperCaseRule.evaluate(0, Row(List(Cell("germany")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 1, column: Country, value: \"germany\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 1, column: Country, value: \"germany\"")
       }
 
     }
@@ -315,13 +315,13 @@ class CaseRuleSpec extends Specification {
 
 
       upperCaseRule.evaluate(0, Row(List(Cell("GeRMANY")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 1, column: Country, value: \"GeRMANY\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 1, column: Country, value: \"GeRMANY\"")
       }
       upperCaseRule.evaluate(0, Row(List(Cell("GeRmANy")), 2), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 2, column: Country, value: \"GeRmANy\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 2, column: Country, value: \"GeRmANy\"")
       }
       upperCaseRule.evaluate(0, Row(List(Cell("gERMANY")), 3), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 3, column: Country, value: \"gERMANY\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 3, column: Country, value: \"gERMANY\"")
       }
 
     }
@@ -334,10 +334,10 @@ class CaseRuleSpec extends Specification {
       val upperCaseRule = UpperCaseRule()
 
       upperCaseRule.evaluate(0, Row(List(Cell("United Kingdom")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 1, column: Country, value: \"United Kingdom\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 1, column: Country, value: \"United Kingdom\"")
       }
       upperCaseRule.evaluate(0, Row(List(Cell("uNITED KINGDOM")), 2), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 2, column: Country, value: \"uNITED KINGDOM\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 2, column: Country, value: \"uNITED KINGDOM\"")
       }
     }
 
@@ -349,10 +349,10 @@ class CaseRuleSpec extends Specification {
       val upperCaseRule = UpperCaseRule()
 
       upperCaseRule.evaluate(0, Row(List(Cell("United Kingdom 11111")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 1, column: Country, value: \"United Kingdom 11111\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 1, column: Country, value: \"United Kingdom 11111\"")
       }
       upperCaseRule.evaluate(0, Row(List(Cell("uNITED KINGDOM 12345")), 2), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 2, column: Country, value: \"uNITED KINGDOM 12345\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 2, column: Country, value: \"uNITED KINGDOM 12345\"")
       }
     }
 
@@ -364,10 +364,10 @@ class CaseRuleSpec extends Specification {
       val upperCaseRule = UpperCaseRule()
 
       upperCaseRule.evaluate(0, Row(List(Cell("United Kingdom 11111 ??")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 1, column: Country, value: \"United Kingdom 11111 ??\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 1, column: Country, value: \"United Kingdom 11111 ??\"")
       }
       upperCaseRule.evaluate(0, Row(List(Cell("uNITED KINGDOM 12345 ?!\"£")), 2), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("upperCase fails for line: 2, column: Country, value: \"uNITED KINGDOM 12345 ?!\"£\"")
+        case Failure(messages) => messages.list mustEqual IList("upperCase fails for line: 2, column: Country, value: \"uNITED KINGDOM 12345 ?!\"£\"")
       }
     }
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/IdenticalRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/IdenticalRuleSpec.scala
@@ -14,7 +14,7 @@ import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema.{ColumnDefinition, NamedColumnIdentifier, Schema, TotalColumns}
 
-import scalaz.{Failure, Success}
+import scalaz.{Failure, Success, IList}
 
 @RunWith(classOf[JUnitRunner])
 class IdenticalRuleSpec extends Specification {
@@ -41,17 +41,17 @@ class IdenticalRuleSpec extends Specification {
       val schema = Schema(globalDirsTwo, List(ColumnDefinition(NamedColumnIdentifier("column1")), ColumnDefinition(NamedColumnIdentifier("column2"))))
       identicalRule1.evaluate(1, Row(List(Cell("row1"),Cell("abc")), 1), schema) mustEqual Success(true)
       identicalRule1.evaluate(1, Row(List(Cell("row1"),Cell("efd")), 2), schema) must beLike {
-        case Failure(msgs) => msgs.list mustEqual(List("identical fails for line: 2, column: column2, value: \"efd\""))
+        case Failure(msgs) => msgs.list mustEqual IList("identical fails for line: 2, column: column2, value: \"efd\"")
       }
       identicalRule1.evaluate(1, Row(List(Cell("row1"),Cell("ghi")), 3), schema) must beLike {
-        case Failure(msgs) => msgs.list mustEqual(List("identical fails for line: 3, column: column2, value: \"ghi\""))
+        case Failure(msgs) => msgs.list mustEqual IList("identical fails for line: 3, column: column2, value: \"ghi\"")
       }
 
       val identicalRule2 = IdenticalRule()
       identicalRule2.evaluate(0, Row(List(Cell("row1"),Cell("abc")), 1), schema) mustEqual Success(true)
       identicalRule2.evaluate(0, Row(List(Cell("row1"),Cell("efd")), 2), schema) mustEqual Success(true)
       identicalRule2.evaluate(0, Row(List(Cell("row2"),Cell("ghi")), 3), schema) must beLike {
-        case Failure(msgs) => msgs.list mustEqual(List("identical fails for line: 3, column: column1, value: \"row2\""))
+        case Failure(msgs) => msgs.list mustEqual IList("identical fails for line: 3, column: column1, value: \"row2\"")
       }
     }
     
@@ -59,16 +59,14 @@ class IdenticalRuleSpec extends Specification {
       val identicalRule = IdenticalRule()
       val schema = Schema(globalDirsTwo, List(ColumnDefinition(NamedColumnIdentifier("column1")), ColumnDefinition(NamedColumnIdentifier("column2"))))
       identicalRule.evaluate(0, Row(List(Cell(""),Cell("abc")), 1), schema) must beLike {
-        case Failure(msgs) => msgs.list mustEqual(List("identical fails for line: 1, column: column1, value: \"\""))
+        case Failure(msgs) => msgs.list mustEqual IList("identical fails for line: 1, column: column1, value: \"\"")
       }
       identicalRule.evaluate(0, Row(List(Cell(""),Cell("efd")), 2), schema) must beLike {
-        case Failure(msgs) => msgs.list mustEqual(List("identical fails for line: 2, column: column1, value: \"\""))
+        case Failure(msgs) => msgs.list mustEqual IList("identical fails for line: 2, column: column1, value: \"\"")
       }
       identicalRule.evaluate(0, Row(List(Cell(""),Cell("ghi")), 3), schema) must beLike {
-        case Failure(msgs) => msgs.list mustEqual(List("identical fails for line: 3, column: column1, value: \"\""))
+        case Failure(msgs) => msgs.list mustEqual IList("identical fails for line: 3, column: column1, value: \"\"")
       }
     }
-
-
   }
 }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/IdenticalRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/IdenticalRuleSpec.scala
@@ -8,13 +8,15 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_1
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema.{ColumnDefinition, NamedColumnIdentifier, Schema, TotalColumns}
 
 import scalaz.{Failure, Success}
 
-
+@RunWith(classOf[JUnitRunner])
 class IdenticalRuleSpec extends Specification {
 
   "IdenticalRule" should  {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/IntegrityCheckRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/IntegrityCheckRuleSpec.scala
@@ -8,7 +8,9 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_1
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator._
 import uk.gov.nationalarchives.csv.validator.api.CsvValidator.SubstitutePath
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
@@ -16,6 +18,7 @@ import uk.gov.nationalarchives.csv.validator.schema._
 
 import scalaz.{Failure, Success}
 
+@RunWith(classOf[JUnitRunner])
 class IntegrityCheckRuleSpec extends Specification with TestResources {
 
 //  val relMustExistForRulePath = relResourcePath("mustExistForRule.csvs")

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/IntegrityCheckRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/IntegrityCheckRuleSpec.scala
@@ -55,21 +55,20 @@ class IntegrityCheckRuleSpec extends Specification with TestResources {
       val totalRows: Some[Boolean] = Some(false)
       
       integrityCheckRule.evaluate(0, Row(List(Cell(relIntegrityCheckForRulePath)), 1), schema, totalRows) must beLike {
-        case Failure(messages) => messages.head mustEqual "integrityCheck fails for line: 1, column: column1, files: \"csv-validator-core/target/test-classes/uk/gov/nationalarchives/csv/validator/schema/v1_1/integrityCheck/folder1/content/file#2.txt\" are not listed in the metadata"
+        case Failure(messages) => messages.head mustEqual "integrityCheck fails for line: 1, column: column1, files: \"target/test-classes/uk/gov/nationalarchives/csv/validator/schema/v1_1/integrityCheck/folder1/content/file#2.txt\" are not listed in the metadata"
       }
     }
 
-     "fail for empty file path" in {
-       val integrityCheckRule = IntegrityCheckRule(emptyPathSubstitutions,false)
-       val schema: Schema = Schema(globalDirsTwo, List(ColumnDefinition(NamedColumnIdentifier("column1")), ColumnDefinition(NamedColumnIdentifier("column2"))))
+    "fail for empty file path" in {
+      val integrityCheckRule = IntegrityCheckRule(emptyPathSubstitutions,false)
+      val schema: Schema = Schema(globalDirsTwo, List(ColumnDefinition(NamedColumnIdentifier("column1")), ColumnDefinition(NamedColumnIdentifier("column2"))))
 
-       integrityCheckRule.evaluate(1, Row(List(Cell("abc"), Cell(relIntegrityCheckForRulePath)), 1), schema, Some(true)) mustEqual  Success(true)
+      integrityCheckRule.evaluate(1, Row(List(Cell("abc"), Cell(relIntegrityCheckForRulePath)), 1), schema, Some(true)) mustEqual  Success(true)
 
-       integrityCheckRule.evaluate(1, Row(List(Cell("abc"), Cell("")), 2), schema, Some(false)) must beLike {
-         case Failure(messages) => messages.head mustEqual "integrityCheck fails for line: 2, column: column2, files: \"csv-validator-core/target/test-classes/uk/gov/nationalarchives/csv/validator/schema/v1_1/integrityCheck/folder1/content/file#2.txt\" are not listed in the metadata"
-       }
-
-     }
+      integrityCheckRule.evaluate(1, Row(List(Cell("abc"), Cell("")), 2), schema, Some(false)) must beLike {
+        case Failure(messages) => messages.head mustEqual "integrityCheck fails for line: 2, column: column2, files: \"target/test-classes/uk/gov/nationalarchives/csv/validator/schema/v1_1/integrityCheck/folder1/content/file#2.txt\" are not listed in the metadata"
+      }
+    }
 
     "succeed for file that exists with no root file path" in {
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/RangeRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/RangeRuleSpec.scala
@@ -14,7 +14,7 @@ import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema.{ColumnDefinition, NamedColumnIdentifier, Schema, TotalColumns}
 
-import scalaz.{Failure, Success}
+import scalaz.{Success, Failure, IList}
 
 @RunWith(classOf[JUnitRunner])
 class RangeRuleSpec extends Specification {
@@ -27,7 +27,7 @@ class RangeRuleSpec extends Specification {
       val rangeRule = new RangeRule(Some(1),Some(2))
 
       rangeRule.evaluate(0, Row(List(Cell("Germany")), 1), schema) must beLike {
-        case Failure(messages) => messages.list mustEqual List("""range(1,2) fails for line: 1, column: Country, value: "Germany"""")
+        case Failure(messages) => messages.list mustEqual IList("""range(1,2) fails for line: 1, column: Country, value: "Germany"""")
       }
     }
 
@@ -53,7 +53,7 @@ class RangeRuleSpec extends Specification {
       val rangeRule = new RangeRule(Some(0.01),Some(0.1))
 
       rangeRule.evaluate(0, Row(List(Cell(("0.00999999999999999999999999999999"))), 1), schema)  must beLike {
-        case Failure(messages) => messages.list mustEqual List("""range(0.01,0.1) fails for line: 1, column: Country, value: "0.00999999999999999999999999999999"""")
+        case Failure(messages) => messages.list mustEqual IList("""range(0.01,0.1) fails for line: 1, column: Country, value: "0.00999999999999999999999999999999"""")
       }
     }
   }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/RangeRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/RangeRuleSpec.scala
@@ -8,13 +8,15 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_1
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema.{ColumnDefinition, NamedColumnIdentifier, Schema, TotalColumns}
 
 import scalaz.{Failure, Success}
 
-
+@RunWith(classOf[JUnitRunner])
 class RangeRuleSpec extends Specification {
 
   "RangeRule" should  {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/SchemaParserSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/SchemaParserSpec.scala
@@ -10,9 +10,12 @@ package uk.gov.nationalarchives.csv.validator.schema.v1_1
 
 import java.io.StringReader
 
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.schema._
 import uk.gov.nationalarchives.csv.validator.schema.v1_0.IsRule
 
+@RunWith(classOf[JUnitRunner])
 class SchemaParserSpec extends SchemaSpecBase {
 
   import TestSchemaParser._

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/SchemaParserVersionSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/SchemaParserVersionSpec.scala
@@ -10,9 +10,12 @@ package uk.gov.nationalarchives.csv.validator.schema.v1_1
 
 import java.io.StringReader
 
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.TestResources
 import uk.gov.nationalarchives.csv.validator.schema._
 
+@RunWith(classOf[JUnitRunner])
 class SchemaParserVersionSpec extends SchemaSpecBase with TestResources{
 
   import TestSchemaParser._

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/SchemaSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/SchemaSpec.scala
@@ -8,11 +8,13 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_1
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema.{TotalColumns, SchemaSpecBase, Literal, Schema}
 
-
+@RunWith(classOf[JUnitRunner])
 class SchemaSpec extends SchemaSpecBase {
 
   "NoExt Arg provider" should {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/SwitchRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/SwitchRuleSpec.scala
@@ -8,13 +8,16 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_1
 
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
 import uk.gov.nationalarchives.csv.validator.schema._
 import uk.gov.nationalarchives.csv.validator.schema.v1_0.{EndsRule, StartsRule}
 
 import scalaz.{Failure, Success}
 
+@RunWith(classOf[JUnitRunner])
 class SwitchRuleSpec extends Specification {
 
   "SwitchRule" should  {

--- a/csv-validator-java-api/pom.xml
+++ b/csv-validator-java-api/pom.xml
@@ -29,6 +29,10 @@
                 <configuration>
                     <recompileMode>incremental</recompileMode>   <!-- NOTE: incremental compilation although faster requires passing to MAVEN_OPTS="-XX:MaxPermSize=128m" -->
                     <useZincServer>true</useZincServer>          <!-- NOTE: if you have Zinc server installed and running, you can get faster compilation by enabling this -->
+                    <args>
+                        <arg>-feature</arg>
+                        <arg>-deprecation</arg>
+                    </args>
                     <javacArgs>
                         <javacArg>-Xlint:unchecked</javacArg>
                         <javacArg>-Xlint:deprecation</javacArg>

--- a/csv-validator-parent/pom.xml
+++ b/csv-validator-parent/pom.xml
@@ -126,25 +126,13 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.2</version>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.19.1</version>
                 </plugin>
                 <plugin>
-                    <groupId>com.mmakowski</groupId>
-                    <artifactId>maven-specs2-plugin</artifactId>
-                    <version>0.4.3</version>
-                    <dependencies>
-                        <!--
-                        Avoid maven-specs2-plugin dependency on com.github.scala-incubator.io:scala-io-file_2.11:0.4.3
-                        as it requires a missing scala-parser-combinators version.
-                        So to workaround, we force a newer version of scala-io-file
-                        -->
-                        <dependency>
-                            <groupId>com.github.scala-incubator.io</groupId>
-                            <artifactId>scala-io-file_${scala.version}</artifactId>
-                            <version>0.4.3-1</version>
-                        </dependency>
-                    </dependencies>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -350,8 +338,32 @@
             </dependency>
             <dependency>
                 <groupId>org.specs2</groupId>
-                <artifactId>specs2_${scala.version}</artifactId>
-                <version>2.4.17</version>
+                <artifactId>specs2-core_${scala.version}</artifactId>
+                <version>${specs2.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.specs2</groupId>
+                <artifactId>specs2-common_${scala.version}</artifactId>
+                <version>${specs2.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.specs2</groupId>
+                <artifactId>specs2-matcher_${scala.version}</artifactId>
+                <version>${specs2.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.specs2</groupId>
+                <artifactId>specs2-junit_${scala.version}</artifactId>
+                <version>${specs2.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/csv-validator-parent/pom.xml
+++ b/csv-validator-parent/pom.xml
@@ -73,7 +73,7 @@
 
     <properties>
         <scala.version>2.11</scala.version>
-        <scala.lib.version>2.11.6</scala.lib.version>
+        <scala.lib.version>2.11.7</scala.lib.version>
         <scalaz.version>7.2.0</scalaz.version>
         <specs2.version>3.7.1</specs2.version>
         <java.version>1.7</java.version>

--- a/csv-validator-parent/pom.xml
+++ b/csv-validator-parent/pom.xml
@@ -74,7 +74,8 @@
     <properties>
         <scala.version>2.11</scala.version>
         <scala.lib.version>2.11.6</scala.lib.version>
-        <scalaz.version>7.1.1</scalaz.version>
+        <scalaz.version>7.2.0</scalaz.version>
+        <specs2.version>3.7.1</specs2.version>
         <java.version>1.7</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <contact.email>digitalpreservation@nationalarchives.gov.uk</contact.email>

--- a/csv-validator-parent/pom.xml
+++ b/csv-validator-parent/pom.xml
@@ -132,6 +132,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-report-plugin</artifactId>
+                    <version>2.19.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.10.2</version>
                 </plugin>

--- a/csv-validator-ui/pom.xml
+++ b/csv-validator-ui/pom.xml
@@ -30,6 +30,10 @@
                 <configuration>
                     <recompileMode>incremental</recompileMode>   <!-- NOTE: incremental compilation although faster requires passing to MAVEN_OPTS="-XX:MaxPermSize=128m" -->
                     <useZincServer>true</useZincServer>          <!-- NOTE: if you have Zinc server installed and running, you can get faster compilation by enabling this -->
+                    <args>
+                        <arg>-feature</arg>
+                        <arg>-deprecation</arg>
+                    </args>
                     <javacArgs>
                         <javacArg>-Xlint:unchecked</javacArg>
                         <javacArg>-Xlint:deprecation</javacArg>


### PR DESCRIPTION
* Closes https://github.com/digital-preservation/csv-validator/issues/110

* Required changes to how tests are executed. Specs are now executed by Surefire and require the class level annotation `@RunWith(classOf[JUnitRunner])`.