### PR TITLE
Skip UTF-8 byte order marks

### DIFF
--- a/csv-validator-core/pom.xml
+++ b/csv-validator-core/pom.xml
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.3.2</version>
+            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>

--- a/csv-validator-core/src/test/resources/uk/gov/nationalarchives/csv/validator/acceptance/bom.csv
+++ b/csv-validator-core/src/test/resources/uk/gov/nationalarchives/csv/validator/acceptance/bom.csv
@@ -1,0 +1,2 @@
+﻿column
+col

--- a/csv-validator-core/src/test/resources/uk/gov/nationalarchives/csv/validator/acceptance/bom.csvs
+++ b/csv-validator-core/src/test/resources/uk/gov/nationalarchives/csv/validator/acceptance/bom.csvs
@@ -1,0 +1,3 @@
+version 1.1
+@totalColumns 1
+column:

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
@@ -565,4 +565,9 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     }
   }
 
+  "Reader" should {
+    "successfully parse byte order marks" in {
+      validate(TextFile(Path.fromString(base) / "bom.csv"), parse(base + "/bom.csvs"), None).isSuccess mustEqual true
+    }
+  }
 }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/UtilSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/UtilSpec.scala
@@ -53,7 +53,7 @@ class UtilSpec extends Specification with TestResources  {
 
       val apiFiles = Util.findAllFiles(true, new File(acceptancePath))
 
-      apiFiles must haveLength(125)
+      apiFiles must haveLength(127)
 
       apiFiles must contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/acceptance/twoRulesPassMetaData.csv"))
 


### PR DESCRIPTION
A UTF-8 file may contain a BOM. As UTF-8 has no need for byte order, this is neither required or recommended but is otherwise legal UTF-8. Java consumes the BOM for UTF-16 and UTF-32, but not for UTF-8 due to backwards compatibility. This pull request uses the Apache Commons BOMInputStream to ignore the UTF-8 BOM.