### PR TITLE
OracleJDK7 is no longer available on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ scala:
 script: "mvn test verify -Dmaven.javadoc.skip=true"
 
 jdk:
-#        - openjdk6
         - openjdk7
-        - oraclejdk7
+        - openjdk8
         - oraclejdk8
 
 notifications:


### PR DESCRIPTION
Fixes the Travis-CI build.