### PR TITLE
Update dependencies to latest, requires Scala 2.12 and Java 1.8

### DIFF
--- a/csv-validator-cmd/pom.xml
+++ b/csv-validator-cmd/pom.xml
@@ -133,6 +133,12 @@
         <dependency>
             <groupId>com.github.scala-incubator.io</groupId>
             <artifactId>scala-io-file_${scala.compat.version}</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.scala-lang.modules</groupId>
+                    <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/csv-validator-cmd/pom.xml
+++ b/csv-validator-cmd/pom.xml
@@ -119,26 +119,12 @@
         </dependency>
         <dependency>
             <groupId>com.github.scopt</groupId>
-            <artifactId>scopt_${scala.compat.version}</artifactId>
+            <artifactId>scopt_${scala.version}</artifactId>
             <version>4.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.scalaz</groupId>
-            <artifactId>scalaz-core_${scala.compat.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.madgag</groupId>
-            <artifactId>scala-arm_${scala.compat.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.github.scala-incubator.io</groupId>
-            <artifactId>scala-io-file_${scala.compat.version}</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.scala-lang.modules</groupId>
-                    <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>scalaz-core_${scala.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -147,22 +133,22 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2-core_${scala.compat.version}</artifactId>
+            <artifactId>specs2-core_${scala.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2-common_${scala.compat.version}</artifactId>
+            <artifactId>specs2-common_${scala.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2-matcher_${scala.compat.version}</artifactId>
+            <artifactId>specs2-matcher_${scala.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2-junit_${scala.compat.version}</artifactId>
+            <artifactId>specs2-junit_${scala.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/csv-validator-cmd/src/main/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdApp.scala
+++ b/csv-validator-cmd/src/main/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdApp.scala
@@ -69,7 +69,7 @@ object CsvValidatorCmdApp extends App {
         opt[Charset]('x', "csv-encoding").optional().action { (x,c) => c.copy(csvEncoding = x) } text("Defines the charset encoding used in the CSV file")
         opt[Charset]('y', "csv-schema-encoding").optional().action { (x,c) => c.copy(csvSchemaEncoding = x) }.text("Defines the charset encoding used in the CSV Schema file")
         opt[Unit]("disable-utf8-validation").optional().action {(_, c) => c.copy(disableUtf8Validation = true)}.text("Disable UTF-8 validation for CSV files.")
-        opt[Unit]("show-progress").optional().action {(_, c) => c.copy(progressCallback = Some(commandLineProgressCallback))}.text("Show progress")
+        opt[Unit]("show-progress").optional().action {(_, c) => c.copy(progressCallback = Some(commandLineProgressCallback()))}.text("Show progress")
         arg[Path]("<csv-path>").validate { x => if(Files.exists(x) && Files.isReadable(x)) success else failure(s"Cannot access CSV file: ${x.toString}") }.action { (x,c) => c.copy(csvPath = x) }.text("The path to the CSV file to validate")
         arg[Path]("<csv-schema-path>").validate { x => if(Files.exists(x) && Files.isReadable(x)) success else failure(s"Cannot access CSV Schema file: ${x.toString}") }.action { (x,c) => c.copy(csvSchemaPath = x) }.text("The path to the CSV Schema file to use for validation")
     }

--- a/csv-validator-cmd/src/main/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdApp.scala
+++ b/csv-validator-cmd/src/main/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdApp.scala
@@ -77,7 +77,15 @@ object CsvValidatorCmdApp extends App {
     //parse the command line arguments
     parser.parse(args, new Config()) map {
       config =>
-        validate(TextFile(config.csvPath, config.csvEncoding, !config.disableUtf8Validation), TextFile(config.csvSchemaPath, config.csvSchemaEncoding), config.failFast, config.substitutePaths, config.caseSensitivePaths, config.traceParser, config.progressCallback)
+        validate(
+          TextFile(config.csvPath, config.csvEncoding, !config.disableUtf8Validation),
+          TextFile(config.csvSchemaPath, config.csvSchemaEncoding),
+          config.failFast,
+          config.substitutePaths,
+          config.caseSensitivePaths,
+          config.traceParser,
+          config.progressCallback
+        )
     } getOrElse {
       //arguments are bad, usage message will have been displayed
       ("", SystemExitCodes.IncorrectArguments)

--- a/csv-validator-cmd/src/main/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdApp.scala
+++ b/csv-validator-cmd/src/main/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdApp.scala
@@ -10,17 +10,17 @@ package uk.gov.nationalarchives.csv.validator.cmd
 
 
 import java.text.DecimalFormat
-
-import resource.managed
-import scalax.file.Path
-import scalaz.{Success => SuccessZ, Failure => FailureZ, _}
+import scalaz.{Failure => FailureZ, Success => SuccessZ, _}
 import scopt.Read
 import uk.gov.nationalarchives.csv.validator._
 import uk.gov.nationalarchives.csv.validator.api.{CsvValidator, TextFile}
 import uk.gov.nationalarchives.csv.validator.api.CsvValidator.{SubstitutePath, createValidator}
+
 import java.net.URL
 import java.nio.charset.Charset
+import java.nio.file.{Files, Path, Paths}
 import java.util.jar.{Attributes, Manifest}
+import scala.util.Using
 
 object SystemExitCodes extends Enumeration {
   type ExitCode = Int
@@ -46,32 +46,32 @@ object CsvValidatorCmdApp extends App {
                     substitutePaths: List[SubstitutePath] = List.empty[SubstitutePath],
                     caseSensitivePaths: Boolean = false,
                     showVersion: Boolean = false,
-                    csvPath: Path = Path.fromString("."),
+                    csvPath: Path = Paths.get("."),
                     csvEncoding: Charset = CsvValidator.DEFAULT_ENCODING,
-                    csvSchemaPath: Path = Path.fromString("."),
+                    csvSchemaPath: Path = Paths.get("."),
                     csvSchemaEncoding: Charset = CsvValidator.DEFAULT_ENCODING,
                     disableUtf8Validation:Boolean = false,
                     progressCallback: Option[ProgressCallback] = None)
 
   def run(args: Array[String]): ExitStatus = {
 
-    implicit val pathRead: Read[Path] = Read.reads { Path.fromString(_) }
+    implicit val pathRead: Read[Path] = Read.reads { Paths.get(_) }
     implicit val charsetRead: Read[Charset] = Read.reads { Charset.forName(_) }
 
     val parser = new scopt.OptionParser[Config]("validate") {
         head("CSV Validator - Command Line", getShortVersion())
         help("help") text("Prints this usage text")
         //opt[Boolean]("version") action { (x,c) => c.copy(showVersion = x) } text { "Display the version information" } //TODO would be nice if '--version' could be used without specifying CSV+CSVS paths etc //getLongVersion().map(x => s"${x._1}: ${x._2}").foreach(println(_))
-        opt[Unit]('t', "trace-parser") optional() action { (_, c) => c.copy(traceParser = true)} text("Prints a trace of the parser parse")
-        opt[Boolean]('f', "fail-fast") optional() action { (x,c) => c.copy(failFast = x) } text("Stops on the first validation error rather than reporting all errors")
-        opt[SubstitutePath]('p', "path") optional() unbounded() action { (x,c) => c.copy(substitutePaths = c.substitutePaths :+ x) } text("Allows you to substitute a file path (or part of) in the CSV for a different file path")
-        opt[Boolean]('c', "case-sensitive-paths") optional() action { (x,c) => c.copy(caseSensitivePaths = x) } text("Enforces case-sensitive file path checking. Useful when validating on case-insensitive filesystems like Windows NTFS")
-        opt[Charset]('x', "csv-encoding") optional() action { (x,c) => c.copy(csvEncoding = x) } text("Defines the charset encoding used in the CSV file")
-        opt[Charset]('y', "csv-schema-encoding") optional() action { (x,c) => c.copy(csvSchemaEncoding = x) } text("Defines the charset encoding used in the CSV Schema file")
-        opt[Unit]("disable-utf8-validation") optional() action {(_, c) => c.copy(disableUtf8Validation = true)} text("Disable UTF-8 validation for CSV files.")
-        opt[Unit]("show-progress") optional() action {(_, c) => c.copy(progressCallback = Some(commandLineProgressCallback))} text("Show progress")
-        arg[Path]("<csv-path>") validate { x => if(x.exists && x.canRead) success else failure(s"Cannot access CSV file: ${x.path}") } action { (x,c) => c.copy(csvPath = x) } text("The path to the CSV file to validate")
-        arg[Path]("<csv-schema-path>") validate { x => if(x.exists && x.canRead) success else failure(s"Cannot access CSV Schema file: ${x.path}") } action { (x,c) => c.copy(csvSchemaPath = x) } text("The path to the CSV Schema file to use for validation")
+        opt[Unit]('t', "trace-parser").optional().action { (_, c) => c.copy(traceParser = true)}.text("Prints a trace of the parser parse")
+        opt[Boolean]('f', "fail-fast").optional().action { (x,c) => c.copy(failFast = x) }.text("Stops on the first validation error rather than reporting all errors")
+        opt[SubstitutePath]('p', "path").optional().unbounded().action { (x,c) => c.copy(substitutePaths = c.substitutePaths :+ x) }.text("Allows you to substitute a file path (or part of) in the CSV for a different file path")
+        opt[Boolean]('c', "case-sensitive-paths").optional().action { (x,c) => c.copy(caseSensitivePaths = x) }.text("Enforces case-sensitive file path checking. Useful when validating on case-insensitive filesystems like Windows NTFS")
+        opt[Charset]('x', "csv-encoding").optional().action { (x,c) => c.copy(csvEncoding = x) } text("Defines the charset encoding used in the CSV file")
+        opt[Charset]('y', "csv-schema-encoding").optional().action { (x,c) => c.copy(csvSchemaEncoding = x) }.text("Defines the charset encoding used in the CSV Schema file")
+        opt[Unit]("disable-utf8-validation").optional().action {(_, c) => c.copy(disableUtf8Validation = true)}.text("Disable UTF-8 validation for CSV files.")
+        opt[Unit]("show-progress").optional().action {(_, c) => c.copy(progressCallback = Some(commandLineProgressCallback))}.text("Show progress")
+        arg[Path]("<csv-path>").validate { x => if(Files.exists(x) && Files.isReadable(x)) success else failure(s"Cannot access CSV file: ${x.toString}") }.action { (x,c) => c.copy(csvPath = x) }.text("The path to the CSV file to validate")
+        arg[Path]("<csv-schema-path>").validate { x => if(Files.exists(x) && Files.isReadable(x)) success else failure(s"Cannot access CSV Schema file: ${x.toString}") }.action { (x,c) => c.copy(csvSchemaPath = x) }.text("The path to the CSV Schema file to use for validation")
     }
 
     //parse the command line arguments
@@ -119,11 +119,10 @@ object CsvValidatorCmdApp extends App {
       None // Class not from JAR
     } else {
       val manifestPath = classPath.substring(0, classPath.lastIndexOf("!") + 1) + "/META-INF/MANIFEST.MF"
-      managed(new URL(manifestPath).openStream()).map {
-        is =>
+      Using(new URL(manifestPath).openStream()) { is =>
           val manifest = new Manifest(is)
           extractor(manifest.getMainAttributes)
-      }.opt
+      }.map(Some(_)).getOrElse(None)
     }
   }
 

--- a/csv-validator-cmd/src/test/scala/uk/gov/nationalarchives/csv/validator/cmd/TestResources.scala
+++ b/csv-validator-cmd/src/test/scala/uk/gov/nationalarchives/csv/validator/cmd/TestResources.scala
@@ -8,9 +8,10 @@
  */
 package uk.gov.nationalarchives.csv.validator.cmd
 
-import java.io.File
 import org.specs2.mutable.Specification
 import uk.gov.nationalarchives.csv.validator.FILE_SEPARATOR
+
+import java.nio.file.Paths
 
 trait TestResources {
 
@@ -22,16 +23,16 @@ trait TestResources {
    *
    * @param resource The path of the resource relative to the spec test
    */
-  def resourcePath(resource: String) : String = new File(baseResourcePkgPath, resource).getAbsolutePath
+  def resourcePath(resource: String) : String = Paths.get(baseResourcePkgPath).resolve(resource).toAbsolutePath.toString
 
-  def baseResourcePkgPath : String = new File(basePath, spec.getClass.getPackage.getName.replace('.', '/')).getAbsolutePath
+  def baseResourcePkgPath : String  = Paths.get(basePath).resolve(spec.getClass.getPackage.getName.replace('.', '/')).toAbsolutePath.toString
 
   def basePath : String = {
     val url = spec.getClass.getClassLoader.getResource(".")
-    new File(url.toURI).getAbsolutePath
+    Paths.get(url.toURI).toAbsolutePath.toString
   }
 
   def relBasePath : String = basePath.replace(System.getProperty("user.dir") + FILE_SEPARATOR, "")
-  def relBaseResourcePkgPath : String = new File(relBasePath, spec.getClass.getPackage.getName.replace('.', '/')).getPath
-  def relResourcePath(resource: String) : String = new File(relBaseResourcePkgPath, resource).getPath
+  def relBaseResourcePkgPath : String = Paths.get(relBasePath).resolve(spec.getClass.getPackage.getName.replace('.', '/')).toString
+  def relResourcePath(resource: String) : String = Paths.get(relBaseResourcePkgPath).resolve(resource).toString
 }

--- a/csv-validator-core/pom.xml
+++ b/csv-validator-core/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.scalaz</groupId>

--- a/csv-validator-core/pom.xml
+++ b/csv-validator-core/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.10.10</version>
+            <version>2.10.13</version>
         </dependency>
         <dependency>
             <groupId>com.univocity</groupId>

--- a/csv-validator-core/pom.xml
+++ b/csv-validator-core/pom.xml
@@ -108,14 +108,19 @@
             <artifactId>scalaz-core_${scala.compat.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.scalaz.stream</groupId>
-            <artifactId>scalaz-stream_${scala.compat.version}</artifactId>
-            <version>0.7.3a</version>
+            <groupId>org.typelevel</groupId>
+            <artifactId>cats-effect_${scala.version}</artifactId>
+            <version>0.4</version>
         </dependency>
         <dependency>
-            <groupId>org.scodec</groupId>
-            <artifactId>scodec-bits_${scala.compat.version}</artifactId>
-            <version>1.1.27</version>
+            <groupId>co.fs2</groupId>
+            <artifactId>fs2-core_${scala.version}</artifactId>
+            <version>0.10.0-M6</version>
+        </dependency>
+        <dependency>
+            <groupId>co.fs2</groupId>
+            <artifactId>fs2-io_${scala.version}</artifactId>
+            <version>0.10.0-M6</version>
         </dependency>
         <dependency>
             <groupId>org.scalaz</groupId>
@@ -123,16 +128,16 @@
             <version>${scalaz.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.scala-incubator.io</groupId>
-            <artifactId>scala-io-file_${scala.compat.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.github.scala-incubator.io</groupId>
-            <artifactId>scala-io-core_${scala.compat.version}</artifactId>
+            <groupId>com.madgag</groupId>
+            <artifactId>scala-io-file_${scala.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.madgag</groupId>
-            <artifactId>scala-arm_${scala.compat.version}</artifactId>
+            <artifactId>scala-io-core_${scala.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.michaelpollmeier</groupId>
+            <artifactId>scala-arm_${scala.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/csv-validator-core/pom.xml
+++ b/csv-validator-core/pom.xml
@@ -100,44 +100,32 @@
         </dependency>
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
+            <artifactId>scala-parser-combinators_${scala.version}</artifactId>
             <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.scalaz</groupId>
-            <artifactId>scalaz-core_${scala.compat.version}</artifactId>
+            <artifactId>scalaz-core_${scala.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.typelevel</groupId>
             <artifactId>cats-effect_${scala.version}</artifactId>
-            <version>0.4</version>
+            <version>3.3.5</version>
         </dependency>
         <dependency>
             <groupId>co.fs2</groupId>
             <artifactId>fs2-core_${scala.version}</artifactId>
-            <version>0.10.0-M6</version>
+            <version>3.2.4</version>
         </dependency>
         <dependency>
             <groupId>co.fs2</groupId>
             <artifactId>fs2-io_${scala.version}</artifactId>
-            <version>0.10.0-M6</version>
+            <version>3.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.scalaz</groupId>
-            <artifactId>scalaz-concurrent_${scala.compat.version}</artifactId>
+            <artifactId>scalaz-concurrent_${scala.version}</artifactId>
             <version>${scalaz.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.madgag</groupId>
-            <artifactId>scala-io-file_${scala.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.madgag</groupId>
-            <artifactId>scala-io-core_${scala.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.michaelpollmeier</groupId>
-            <artifactId>scala-arm_${scala.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
@@ -150,9 +138,9 @@
             <version>2.9.1</version>
         </dependency>
         <dependency>
-            <groupId>com.gilt</groupId>
-            <artifactId>gfc-semver_${scala.compat.version}</artifactId>
-            <version>0.0.5</version>
+            <groupId>org.gfccollective</groupId>
+            <artifactId>gfc-semver_${scala.version}</artifactId>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.nationalarchives</groupId>
@@ -166,22 +154,22 @@
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2-core_${scala.compat.version}</artifactId>
+            <artifactId>specs2-core_${scala.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2-common_${scala.compat.version}</artifactId>
+            <artifactId>specs2-common_${scala.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2-matcher_${scala.compat.version}</artifactId>
+            <artifactId>specs2-matcher_${scala.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>
-            <artifactId>specs2-junit_${scala.compat.version}</artifactId>
+            <artifactId>specs2-junit_${scala.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/csv-validator-core/pom.xml
+++ b/csv-validator-core/pom.xml
@@ -157,7 +157,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.specs2</groupId>

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/FailFastMetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/FailFastMetaDataValidator.scala
@@ -55,11 +55,12 @@ trait FailFastMetaDataValidator extends MetaDataValidator {
     @tailrec
     def validateRules(columnDefinitions: List[(ColumnDefinition, Int)], accum: List[MetaDataValidation[Any]] = List.empty) : List[MetaDataValidation[Any]] = {
       columnDefinitions match {
-        case Nil if(accum.isEmpty) =>
-          List(true.successNel[FailMessage])
-
-        case Nil if(accum.nonEmpty) =>
-          accum.reverse
+        case Nil =>
+          if (accum.isEmpty) {
+            List(true.successNel[FailMessage])
+          } else {
+            accum.reverse
+          }
 
         case (columnDefinition, columnIndex) :: tail =>
           validateCell(columnIndex, cells, row, schema, mayBeLast) match {

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidator.scala
@@ -154,7 +154,7 @@ trait MetaDataValidator {
             validateRows(rowIt, schema)
         }
 
-    } either match {
+    }.either.either match {
       case Right(metadataValidation) =>
         metadataValidation
 

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/Util.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/Util.scala
@@ -100,7 +100,7 @@ object Util {
     } match {
       case util.Success(list) if list.nonEmpty =>
         list
-      case util.Failure(_) =>
+      case _ =>
         Seq.empty
     }
   }
@@ -121,9 +121,9 @@ object Util {
         .collect(Collectors.toList[P])
         .asScala.toSeq.map(_.asInstanceOf[Path])
     } match {
-      case util.Success(list) if list.nonEmpty =>
+      case util.Success(list) =>
         list
-      case util.Failure(_) =>
+      case _ =>
         Seq.empty
     }
   }

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/Util.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/Util.scala
@@ -15,7 +15,7 @@ import Scalaz._
 import java.util.regex.{Matcher, Pattern}
 import java.net.URI
 import scala.util.{Try, Using}
-import java.io.{FileNotFoundException, FilenameFilter}
+import java.io.FileNotFoundException
 import java.net.URLDecoder
 import java.nio.file.{FileVisitOption, Files, Path, Paths, SimpleFileVisitor}
 import java.util.stream.Collectors
@@ -230,8 +230,8 @@ object Util {
       * This ensures case-sensitivity
       * and is useful on platforms such as
       * Windows NTFS which are case-insensitive,
-      * where new File("test.txt").exists
-      * and new File("TEST.TXT").exists
+      * where {@code Files.exists(Paths.get("test.txt"))}
+      * and {@code Files.exists(Paths.get("TEST.TXT"))}
       * may both return true when there is
       * only one file.
       */

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/Util.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/Util.scala
@@ -9,15 +9,18 @@
 package uk.gov.nationalarchives.csv.validator
 
 import scala.language.postfixOps
-import scalax.file.Path
 import scalaz._
 import Scalaz._
+
 import java.util.regex.{Matcher, Pattern}
 import java.net.URI
-import scala.util.Try
-import java.io.{FileNotFoundException, FilenameFilter, File}
+import scala.util.{Try, Using}
+import java.io.{FileNotFoundException, FilenameFilter}
 import java.net.URLDecoder
+import java.nio.file.{FileVisitOption, Files, Path, Paths, SimpleFileVisitor}
+import java.util.stream.Collectors
 import scala.annotation.tailrec
+import scala.jdk.CollectionConverters._
 
 
 object Util {
@@ -26,9 +29,9 @@ object Util {
 
   def checkFilesReadable(files: List[Path]) = files.map(fileReadable).sequence[AppValidation, FailMessage]
 
-  def fileReadable(file: Path): AppValidation[FailMessage] = if (file.exists && file.canRead) FailMessage(SchemaDefinitionError, file.path).successNel[FailMessage] else fileNotReadableMessage(file).failureNel[FailMessage]
+  def fileReadable(file: Path): AppValidation[FailMessage] = if (Files.exists(file) && Files.isReadable(file)) FailMessage(SchemaDefinitionError, file.toAbsolutePath.toString).successNel[FailMessage] else fileNotReadableMessage(file).failureNel[FailMessage]
 
-  def fileNotReadableMessage(file: Path) = FailMessage(SchemaDefinitionError, "Unable to read file : " + file.path)
+  def fileNotReadableMessage(file: Path) = FailMessage(SchemaDefinitionError, "Unable to read file : " + file.toAbsolutePath)
 
   /**
     * Check if the list l1 contain all element in l2
@@ -65,17 +68,67 @@ object Util {
     * @param folder
     * @return List of all filename
     */
-  def findAllFiles(includeFolder : Boolean,folder: File): Set[File] = {
-    if (folder.exists()){
-      val these = folder.listFiles.toSet
+  def findAllFiles(includeFolder : Boolean, folder: Path): Set[Path] = {
+    if (Files.exists(folder)) {
+      val these = children(folder, _ => true).toSet
       val head = if (includeFolder) Set(folder) else Nil
-      (head ++ these.filter( f => if (!includeFolder) f.isFile else true) ++ these.filter(f => f.isDirectory && !(f.getName == "RECYCLER") && !(f.getName == "$RECYCLE.BIN")).flatMap(file => findAllFiles(includeFolder, file))).toSet
+      (head ++ these.filter( f => if (!includeFolder) !Files.isDirectory(f) else true) ++ these.filter(f => Files.isDirectory(f) && !(f.getFileName.toString == "RECYCLER") && !(f.getFileName.toString == "$RECYCLE.BIN")).flatMap(file => findAllFiles(includeFolder, file))).toSet
     }
     else
       throw new FileNotFoundException(s"Cannot find the folder $folder")
   }
 
+  class fileTreePredicateVisitor extends SimpleFileVisitor[Path] {
 
+  }
+
+  def descendants[P >: Path](path: Path, pattern: String) : Seq[Path] = {
+    val matcher = Pattern.compile(pattern).matcher("")
+    descendants(path, path => {
+        matcher.reset(path.getFileName.toString)
+        matcher.matches()
+    })
+  }
+
+  def descendants[P >: Path](path: Path, predicate: P => Boolean) : Seq[Path] = {
+    val x = Files.walk(path, Array.empty[FileVisitOption] :_*)
+    Using(x) { stream =>
+      stream
+        .filter(p => predicate(p))
+        .collect(Collectors.toList[P])
+        .asScala.toSeq.map(_.asInstanceOf[Path])
+    } match {
+      case util.Success(list) if list.nonEmpty =>
+        list
+      case util.Failure(_) =>
+        Seq.empty
+    }
+  }
+
+  def children[P >: Path](path: Path, pattern: String) : Seq[Path] = {
+    val matcher = Pattern.compile(pattern).matcher("")
+    children(path, path => {
+      matcher.reset(path.getFileName.toString)
+      matcher.matches()
+    })
+  }
+
+  def children[P >: Path](path: Path, predicate: P => Boolean) : Seq[Path] = {
+    val x = Files.walk(path, 1, Array.empty[FileVisitOption] :_*)
+    Using(x) { stream =>
+      stream
+        .filter(p => predicate(p))
+        .collect(Collectors.toList[P])
+        .asScala.toSeq.map(_.asInstanceOf[Path])
+    } match {
+      case util.Success(list) if list.nonEmpty =>
+        list
+      case util.Failure(_) =>
+        Seq.empty
+    }
+  }
+
+  def listFiles(path: Path) : Seq[Path] = children(path, p => !Files.isDirectory(p))
 
   abstract class TypedPath {
 
@@ -152,7 +205,7 @@ object Util {
 
 
   object FileSystem {
-    def createFile(filename: String): Try[File] =  Try{ if( filename.startsWith("file:")) new File( new URI(file2PlatformIndependent(filename))) else  new File( URLDecoder.decode(filename, ENCODING.name()) )} //TODO encoding shudld not be hard-coded here. Should be determined from cmd-line/ui user setting
+    def createFile(filename: String): Try[Path] =  Try{ if( filename.startsWith("file:")) Paths.get(new URI(file2PlatformIndependent(filename))) else Paths.get(URLDecoder.decode(filename, ENCODING.name()) )} //TODO encoding shudld not be hard-coded here. Should be determined from cmd-line/ui user setting
 
     def replaceSpaces(file: String): String = file.replace(" ", "%20")
 
@@ -183,17 +236,15 @@ object Util {
       * only one file.
       */
     @tailrec
-    final def caseSensitivePathMatchesFs(f: File): Boolean = {
+    final def caseSensitivePathMatchesFs(f: Path): Boolean = {
 
-      val parent = Option(f.getAbsoluteFile.getParentFile)
+      val parent : Option[Path] = Option(f.toAbsolutePath.getParent)
       parent match {
         case None =>
           true //used to exit
 
         case Some(p) =>
-          val foundChild = p.list(new FilenameFilter {
-            def accept(dir: File, name: String): Boolean = name == f.getName
-          })
+          val foundChild = children(p, p => p.getFileName.toString == f.getFileName.toString)
           foundChild.nonEmpty && caseSensitivePathMatchesFs(p)
       }
     }
@@ -245,7 +296,7 @@ object Util {
 
       FileSystem.createFile(FileSystem.convertPath2Platform(substitutePath(jointPath))) match {
         case scala.util.Success(f) => {
-          val exists = f.exists
+          val exists = Files.exists(f)
           if(exists && enforceCaseSensitivePathChecks) {
             FileSystem.caseSensitivePathMatchesFs(f)
           } else {
@@ -256,13 +307,13 @@ object Util {
       }
     }
 
-    def scanDir(dir: File, includeFolder: Boolean): Set[File] = findAllFiles(dir, includeFolder)
+    def scanDir(dir: Path, includeFolder: Boolean): Set[Path] = findAllFiles(dir, includeFolder)
 
-    def findAllFiles(folder: File, includeFolder : Boolean): Set[File] = {
-      if (folder.exists()){
-        val these = folder.listFiles.toSet
+    def findAllFiles(folder: Path, includeFolder : Boolean): Set[Path] = {
+      if (Files.exists(folder)) {
+        val these = listFiles(folder).toSet
         val head = if (includeFolder) Set(folder) else Nil
-        (head ++ these.filter( f => if (!includeFolder) f.isFile else true) ++ these.filter(f => f.isDirectory && !(f.getName == "RECYCLER") && !(f.getName == "$RECYCLE.BIN")).flatMap(file => findAllFiles(file, includeFolder))).toSet
+        (head ++ these.filter( f => if (!includeFolder) !Files.isDirectory(f) else true) ++ these.filter(f => Files.isDirectory(f) && !(f.getFileName.toString == "RECYCLER") && !(f.getFileName.toString == "$RECYCLE.BIN")).flatMap(file => findAllFiles(file, includeFolder))).toSet
       }
       else
         throw new FileNotFoundException(s"Cannot find the folder $folder")
@@ -271,13 +322,13 @@ object Util {
 
 
 
-    def integrityCheck(fileMap: Map[String, Set[File]],  enforceCaseSensitivePathChecks: Boolean, topLevelFolder: String, includeFolder: Boolean): Map[String, Set[File]] = {
+    def integrityCheck(fileMap: Map[String, Set[Path]], enforceCaseSensitivePathChecks: Boolean, topLevelFolder: String, includeFolder: Boolean): Map[String, Set[Path]] = {
       val contentDirectory = contentDir(jointPath, topLevelFolder)
       val files = fileMap.get(contentDirectory).getOrElse{
         val theFiles = FileSystem.createFile(FileSystem.convertPath2Platform(contentDirectory)) match
             {
               case scala.util.Success(f) => scanDir(f, includeFolder)
-              case scala.util.Failure(_) => Set[File]()
+              case scala.util.Failure(_) => Set[Path]()
             }
             theFiles
         }
@@ -286,7 +337,7 @@ object Util {
         case _ => files
       }
 
-      fileMap.filterKeys(_ == contentDirectory) + (contentDirectory -> remainder)
+      fileMap.view.filterKeys(_ == contentDirectory).toMap + (contentDirectory -> remainder)
     }
 
     def expandBasePath: String = {

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidator.scala
@@ -9,11 +9,13 @@
 package uk.gov.nationalarchives.csv.validator.api
 
 import uk.gov.nationalarchives.csv.validator.schema.{Schema, SchemaParser}
-import scalaz._, Scalaz._
-import scalax.file.Path
+import scalaz._
+import Scalaz._
 import uk.gov.nationalarchives.csv.validator._
-import _root_.java.io.{Reader => JReader, File}
-import _root_.java.nio.charset.{Charset => JCharset}
+
+import java.io.{Reader => JReader}
+import java.nio.charset.{Charset => JCharset}
+import java.nio.file.Path
 
 object CsvValidator {
 

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaParser.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaParser.scala
@@ -8,6 +8,7 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema
 
+import uk.gov.nationalarchives.csv.validator.schema.SchemaValidator
 import uk.gov.nationalarchives.csv.validator.schema.v1_0.{SchemaParser => SchemaParser1_0}
 import uk.gov.nationalarchives.csv.validator.schema.v1_1.{SchemaParser => SchemaParser1_1, _}
 import uk.gov.nationalarchives.csv.validator.schema.v1_2.{SchemaParser => SchemaParser1_2, _}

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaValidator.scala
@@ -8,7 +8,7 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema
 
-import com.gilt.gfc.semver.SemVer
+import org.gfccollective.semver.SemVer
 import uk.gov.nationalarchives.csv.validator.schema.v1_0.{SchemaValidator => SchemaValidator1_0}
 import uk.gov.nationalarchives.csv.validator.schema.v1_1.{SchemaValidator => SchemaValidator1_1}
 

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/Rule.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/Rule.scala
@@ -410,7 +410,7 @@ case class ChecksumRule(rootPath: ArgProvider, file: ArgProvider, algorithm: Str
           checksum(f)
         }
 
-      case scala.util.Failure(_) =>
+      case _ =>
         s"""file "${FileSystem.file2PatformDependent(file)}" not found""".failureNel[String]
     }
   }
@@ -577,7 +577,7 @@ trait FileWildcardSearch[T] {
       } else if(!fileExists) {
         s"""file "${TypedPath(fullPath).toPlatform}" not found""".failureNel[T]
       } else {
-        matchSimplePath(basePath + System.getProperty("file.separator") + matchPath)
+        matchSimplePath(basePath.toString + System.getProperty("file.separator") + matchPath)
       }
     } catch {
       case err:Throwable =>

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/Rule.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/Rule.scala
@@ -8,8 +8,7 @@
  */
 package uk.gov.nationalarchives.csv.validator.schema.v1_1
 
-import java.io.{FileNotFoundException, File}
-
+import java.io.FileNotFoundException
 import uk.gov.nationalarchives.csv.validator.Util.FileSystem
 import uk.gov.nationalarchives.csv.validator.metadata.Row
 import uk.gov.nationalarchives.csv.validator.schema._
@@ -18,6 +17,8 @@ import uk.gov.nationalarchives.csv.validator.schema.v1_0.{DateRangeRule, IsoDate
 import scala.util.Try
 import scalaz.Scalaz._
 import scalaz.{Failure => FailureZ, Success => SuccessZ}
+
+import java.nio.file.Path
 
 
 
@@ -74,7 +75,7 @@ case class SwitchRule(elseRules: Option[List[Rule]], cases:(Rule, List[Rule])*) 
 case class IntegrityCheckRule(pathSubstitutions: List[(String,String)], enforceCaseSensitivePathChecks: Boolean, rootPath: ArgProvider = Literal(None), topLevelFolder: String = "content", includeFolder: Boolean = false) extends Rule("integrityCheck", Seq(rootPath): _*) {
 
   //TODO introduce state, not very functional
-  var filesMap = Map[String, Set[File]]()
+  var filesMap = Map[String, Set[Path]]()
 
   override def evaluate(columnIndex: Int, row: Row,  schema: Schema, mayBeLast: Option[Boolean] = None): RuleValidation[Any] = {
     try{

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
@@ -13,10 +13,13 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import scalaz._
 import uk.gov.nationalarchives.csv.validator.schema.Schema
-import uk.gov.nationalarchives.csv.validator.api.{TextFile, CsvValidator}
-import scalax.file.Path
+import uk.gov.nationalarchives.csv.validator.api.{CsvValidator, TextFile}
+
 import java.io.StringReader
 import java.io
+import java.nio.file.{Files, Paths}
+
+import scala.jdk.CollectionConverters._
 
 @RunWith(classOf[JUnitRunner])
 class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
@@ -40,36 +43,36 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
   import v.{validate, validateR, parseSchema}
   import ve.{validate => validateE, parseSchema => parseSchemaE}
 
-  def parse(filePath: String): Schema = parseSchema(TextFile(Path.fromString(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
-  def parseE(filePath: String): Schema = parseSchemaE(TextFile(Path.fromString(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
+  def parse(filePath: String): Schema = parseSchema(TextFile(Paths.get(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
+  def parseE(filePath: String): Schema = parseSchemaE(TextFile(Paths.get(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
 
   def parse(reader: io.Reader): Schema = parseSchema(reader) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
   def parseE(reader: io.Reader): Schema = parseSchemaE(reader) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
 
   "@separator global directive" should {
     "succeed for '$' separator" in {
-      validate(TextFile(Path.fromString(base) / "separated1.dsv"), parse(base + "/separated1.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("separated1.dsv")), parse(base + "/separated1.csvs"), None).isSuccess mustEqual true
     }
 
     "succeed for TAB separator" in {
-      validate(TextFile(Path.fromString(base) / "separated2.tsv"), parse(base + "/separated2.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("separated2.tsv")), parse(base + "/separated2.csvs"), None).isSuccess mustEqual true
     }
 
     "succeed for '\t' separator" in {
-      validate(TextFile(Path.fromString(base) / "separated2.tsv"), parse(base + "/separated2-1.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("separated2.tsv")), parse(base + "/separated2-1.csvs"), None).isSuccess mustEqual true
     }
 
     "with @quoted global directive" should {
       "succeed for '$' separator" in {
-        validate(TextFile(Path.fromString(base) / "separated3.dsv"), parse(base + "/separated3.csvs"), None).isSuccess mustEqual true
+        validate(TextFile(Paths.get(base).resolve("separated3.dsv")), parse(base + "/separated3.csvs"), None).isSuccess mustEqual true
       }
 
       "succeed for TAB separator" in {
-        validate(TextFile(Path.fromString(base) / "separated4.tsv"), parse(base + "/separated4.csvs"), None).isSuccess mustEqual true
+        validate(TextFile(Paths.get(base).resolve("separated4.tsv")), parse(base + "/separated4.csvs"), None).isSuccess mustEqual true
       }
 
       "succeed for '\t' separator" in {
-        validate(TextFile(Path.fromString(base) / "separated4.tsv"), parse(base + "/separated4-1.csvs"), None).isSuccess mustEqual true
+        validate(TextFile(Paths.get(base).resolve("separated4.tsv")), parse(base + "/separated4-1.csvs"), None).isSuccess mustEqual true
       }
     }
   }
@@ -77,11 +80,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
   "Regex rule" should {
 
     "succeed for metadata file with column that passes regex rule" in {
-      validate(TextFile(Path.fromString(base) / "regexRulePassMetaData.csv"), parse(base + "/regexRuleSchema.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("regexRulePassMetaData.csv")), parse(base + "/regexRuleSchema.csvs"), None).isSuccess mustEqual true
     }
 
     "fail when @noHeader not set" in {
-      validate(TextFile(Path.fromString(base) / "regexRuleFailMetaData.csv"), parse(base + "/regexRuleSchemaWithoutNoHeaderSet.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("regexRuleFailMetaData.csv")), parse(base + "/regexRuleSchemaWithoutNoHeaderSet.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, "regex(\"[0-9]+\") fails for line: 1, column: Age, value: \"twenty\"",Some(1),Some(1))
         )
@@ -92,13 +95,13 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "Not empty rule" should {
     "succeed for metadata file with column that passes regex rule" in {
-      validate(TextFile(Path.fromString(base) / "notempty.csv"), parse(base + "/notempty.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("notempty.csv")), parse(base + "/notempty.csvs"), None).isSuccess mustEqual true
     }
   }
 
   "Multiple errors " should {
     "all be reported" in {
-      validate(TextFile(Path.fromString(base) / "multipleErrorsMetaData.csv"), parse(base + "/regexRuleSchemaWithNoHeaderSet.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("multipleErrorsMetaData.csv")), parse(base + "/regexRuleSchemaWithNoHeaderSet.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, """regex("[0-9]+") fails for line: 1, column: Age, value: "twenty"""",Some(1),Some(1)),
           FailMessage(ValidationError, """regex("[0-9]+") fails for line: 2, column: Age, value: "thirty"""",Some(2),Some(1)))
@@ -108,11 +111,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "Combining two rules" should {
     "succeed when metadata valid" in {
-      validate(TextFile(Path.fromString(base) / "twoRulesPassMetaData.csv"), parse(base + "/twoRuleSchema.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("twoRulesPassMetaData.csv")), parse(base + "/twoRuleSchema.csvs"), None).isSuccess mustEqual true
     }
 
     "fail when rules fail for all permutations" in {
-      validate(TextFile(Path.fromString(base) / "twoRulesFailMetaData.csv"), parse(base + "/twoRuleSchemaFail.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("twoRulesFailMetaData.csv")), parse(base + "/twoRuleSchemaFail.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, """in($FullName) fails for line: 1, column: Name, value: "Ben"""",Some(1),Some(0)),
           FailMessage(ValidationError, """regex("[a-z]+") fails for line: 1, column: Name, value: "Ben"""",Some(1),Some(0)),
@@ -124,15 +127,15 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "An if rule" should {
     "succeed if the conditionExpr and thenExpr are respected" in {
-      validate(TextFile(Path.fromString(base) / "ifRulePassMetaData.csv"), parse(base + "/ifRuleSchema.csvs"), None).isSuccess mustEqual  true
+      validate(TextFile(Paths.get(base).resolve("ifRulePassMetaData.csv")), parse(base + "/ifRuleSchema.csvs"), None).isSuccess mustEqual  true
     }
 
     "succeed if the condition and thenExpr or elseExpr are respected" in {
-      validate(TextFile(Path.fromString(base) / "ifRulePassMetaData.csv"), parse(base + "/ifElseRuleSchema.csvs"), None).isSuccess mustEqual  true
+      validate(TextFile(Paths.get(base).resolve("ifRulePassMetaData.csv")), parse(base + "/ifElseRuleSchema.csvs"), None).isSuccess mustEqual  true
     }
 
     "fail if the conditionExpr is true but the thenExpr is false" in {
-      validate(TextFile(Path.fromString(base) / "ifRuleFailThenMetaData.csv"), parse(base + "/ifElseRuleSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("ifRuleFailThenMetaData.csv")), parse(base + "/ifElseRuleSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, """is("hello world") fails for line: 1, column: SomeIfRule, value: "hello world1"""",Some(1),Some(1))
         )
@@ -140,7 +143,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     }
 
     "fail if the conditionExpr is fasle but the elseExpr is false" in {
-      validate(TextFile(Path.fromString(base) / "ifRuleFailElseMetaData.csv"), parse(base + "/ifElseRuleSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("ifRuleFailElseMetaData.csv")), parse(base + "/ifElseRuleSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, """upperCase fails for line: 3, column: SomeIfRule, value: "EFQWeGW"""",Some(3),Some(1))
         )
@@ -150,15 +153,15 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "An switch rule" should {
     "succeed if the conditionExpr and thenExpr are respected - 1" in {
-      validate(TextFile(Path.fromString(base) / "switch1RulePassMetaData.csv"), parse(base + "/switch1RuleSchema.csvs"), None).isSuccess mustEqual  true
+      validate(TextFile(Paths.get(base).resolve("switch1RulePassMetaData.csv")), parse(base + "/switch1RuleSchema.csvs"), None).isSuccess mustEqual  true
     }
 
     "succeed if the conditionExpr and thenExpr are respected - 2" in {
-      validate(TextFile(Path.fromString(base) / "switch2RulePassMetaData.csv"), parse(base + "/switch2RuleSchema.csvs"), None).isSuccess mustEqual  true
+      validate(TextFile(Paths.get(base).resolve("switch2RulePassMetaData.csv")), parse(base + "/switch2RuleSchema.csvs"), None).isSuccess mustEqual  true
     }
 
     "fail if the conditionExpr is true but the thenExpr is false - 1" in {
-      validate(TextFile(Path.fromString(base) / "switch1RuleFailMetaData.csv"), parse(base + "/switch1RuleSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("switch1RuleFailMetaData.csv")), parse(base + "/switch1RuleSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, """is("hello world") fails for line: 1, column: SomeSwitchRule, value: "hello world1"""",Some(1),Some(1))
         )
@@ -166,7 +169,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     }
 
     "fail if the conditionExpr is true but the thenExpr is false - 2" in {
-      validate(TextFile(Path.fromString(base) / "switch2RuleFailMetaData.csv"), parse(base + "/switch2RuleSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("switch2RuleFailMetaData.csv")), parse(base + "/switch2RuleSchema.csvs"), None) must beLike {
         case Failure(errors) =>errors.list mustEqual IList(
           FailMessage(ValidationError, """is("hello world") fails for line: 1, column: SomeSwitchRule, value: "hello world1"""",Some(1),Some(1)),
           FailMessage(ValidationError, """is("HELLO WORLD") fails for line: 2, column: SomeSwitchRule, value: "HELLO WORLD1"""",Some(2),Some(1))
@@ -179,11 +182,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "An in rule" should {
     "succeed if the column value is in the rule's literal string" in {
-      validate(TextFile(Path.fromString(base) / "inRulePassMetaData.csv"), parse(base + "/inRuleSchema.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("inRulePassMetaData.csv")), parse(base + "/inRuleSchema.csvs"), None).isSuccess mustEqual true
     }
 
     "fail if the column value is not in the rule's literal string" in {
-      validate(TextFile(Path.fromString(base) / "inRuleFailMetaData.csv"), parse(base + "/inRuleSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("inRuleFailMetaData.csv")), parse(base + "/inRuleSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, """in("thevaluemustbeinthisstring") fails for line: 1, column: SomeInRule, value: "valuenotinrule"""",Some(1),Some(1)),
           FailMessage(ValidationError, """in("thevaluemustbeinthisstring") fails for line: 3, column: SomeInRule, value: "thisonewillfailtoo"""",Some(3),Some(1)))
@@ -191,11 +194,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     }
 
     "succeed if the column value is in the rule's cross referenced column" in {
-      validate(TextFile(Path.fromString(base) / "inRuleCrossReferencePassMetaData.csv"), parse(base + "/inRuleCrossReferenceSchema.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("inRuleCrossReferencePassMetaData.csv")), parse(base + "/inRuleCrossReferenceSchema.csvs"), None).isSuccess mustEqual true
     }
 
     "fail if the column value is not in the rule's cross referenced column" in {
-      validate(TextFile(Path.fromString(base) / "inRuleCrossReferenceFailMetaData.csv"), parse(base + "/inRuleCrossReferenceSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("inRuleCrossReferenceFailMetaData.csv")), parse(base + "/inRuleCrossReferenceSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """in($FullName) fails for line: 2, column: FirstName, value: "Dave"""",Some(2),Some(0)))
       }
     }
@@ -203,11 +206,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "An any rule" should {
     "succeed if the column value is in the rule's literal string" in {
-      validate(TextFile(Path.fromString(base) / "anyRulePassMetaData.csv"), parse(base + "/anyRuleSchema.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("anyRulePassMetaData.csv")), parse(base + "/anyRuleSchema.csvs"), None).isSuccess mustEqual true
     }
 
     "fail if the column value is not in the rule's literal string" in {
-      validate(TextFile(Path.fromString(base) / "anyRuleFailMetaData.csv"), parse(base + "/anyRuleSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("anyRuleFailMetaData.csv")), parse(base + "/anyRuleSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, """any("value1", "value2", "value3") fails for line: 4, column: SomeAnyRule, value: "value4"""",Some(4),Some(1))
         )
@@ -217,11 +220,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "A xsdDateTime rule" should {
     "succeed if the column value is in the rule's literal string" in {
-      validate(TextFile(Path.fromString(base) / "xsdDateTimePass.csv"), parse(base + "/xsdDateTime.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("xsdDateTimePass.csv")), parse(base + "/xsdDateTime.csvs"), None).isSuccess mustEqual true
     }
 
     "fail if the column value is not in the rule's literal string" in {
-      validate(TextFile(Path.fromString(base) / "xsdDateTimeFail.csv"), parse(base + "/xsdDateTime.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("xsdDateTimeFail.csv")), parse(base + "/xsdDateTime.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, """xDateTime fails for line: 2, column: date, value: "2013-03-22"""",Some(2),Some(0))
         )
@@ -231,11 +234,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "A xsdDateTimeRange rule" should {
     "succeed if the column value is in the rule's literal string" in {
-      validate(TextFile(Path.fromString(base) / "xsdDateTimeRangePass.csv"), parse(base + "/xsdDateTimeRange.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("xsdDateTimeRangePass.csv")), parse(base + "/xsdDateTimeRange.csvs"), None).isSuccess mustEqual true
     }
 
     "fail if the column value is not in the rule's literal string" in {
-      validate(TextFile(Path.fromString(base) / "xsdDateTimeRangeFail.csv"), parse(base + "/xsdDateTimeRange.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("xsdDateTimeRangeFail.csv")), parse(base + "/xsdDateTimeRange.csvs"), None) must beLike {
         case Failure(errors) => errors.list  mustEqual IList(
           FailMessage(ValidationError, """xDateTime("2012-01-01T01:00:00, 2013-01-01T01:00:00") fails for line: 2, column: date, value: "2014-01-01T01:00:00"""",Some(2),Some(0))
         )
@@ -246,11 +249,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
   //FIXME
   "A xsdDateTimeWithTimeZone rule" should {
     "succeed if the column value is in the rule's literal string" in {
-      validate(TextFile(Path.fromString(base) / "xsdDateTimeTzPass.csv"), parse(base + "/xsdDateTimeTz.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("xsdDateTimeTzPass.csv")), parse(base + "/xsdDateTimeTz.csvs"), None).isSuccess mustEqual true
     }
 
     "fail if the column value is invalid" in {
-      validate(TextFile(Path.fromString(base) / "xsdDateTimeTzFail.csv"), parse(base + "/xsdDateTimeTz.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("xsdDateTimeTzFail.csv")), parse(base + "/xsdDateTimeTz.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, """xDateTimeWithTimeZone fails for line: 4, column: date, value: "2012-01-01T00:00:00"""",Some(4),Some(0))
         )
@@ -260,11 +263,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "A xsdDateTimeWithTimeZoneRange rule" should {
     "succeed if the column value is in the rule's literal string" in {
-      validate(TextFile(Path.fromString(base) / "xsdDateTimeTzRangePass.csv"), parse(base + "/xsdDateTimeTzRange.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("xsdDateTimeTzRangePass.csv")), parse(base + "/xsdDateTimeTzRange.csvs"), None).isSuccess mustEqual true
     }
 
     "fail if the column value is not in the rule's literal string" in {
-      validate(TextFile(Path.fromString(base) / "xsdDateTimeTzRangeFail.csv"), parse(base + "/xsdDateTimeTzRange.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("xsdDateTimeTzRangeFail.csv")), parse(base + "/xsdDateTimeTzRange.csvs"), None) must beLike {
         case Failure(errors) => errors.list  mustEqual IList(
           FailMessage(ValidationError, """xDateTimeWithTimeZone("2012-01-01T01:00:00+00:00, 2013-01-01T01:00:00+00:00") fails for line: 2, column: date, value: "2014-01-01T01:00:00+00:00"""",Some(2),Some(0))
         )
@@ -276,11 +279,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "An @optional column directive" should {
     "allow a column to have an empty value and ignore other rules" in {
-      validate(TextFile(Path.fromString(base) / "optionalPassMetaData.csv"), parse(base + "/optionalSchema.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("optionalPassMetaData.csv")), parse(base + "/optionalSchema.csvs"), None).isSuccess mustEqual true
     }
 
     "fail if a non empty value fails a rule" in {
-      validate(TextFile(Path.fromString(base) / "optionalFailMetaData.csv"), parse(base + "/optionalSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("optionalFailMetaData.csv")), parse(base + "/optionalSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, "in($FullName) fails for line: 1, column: Name, value: \"BP\"",Some(1),Some(0)))
       }
     }
@@ -288,31 +291,31 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "An @ignoreCase column directive" should {
     "pass a rule ignoring case" in {
-      validate(TextFile(Path.fromString(base) / "ignoreCasePassMetaData.csv"), parse(base + "/ignoreCaseSchema.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("ignoreCasePassMetaData.csv")), parse(base + "/ignoreCaseSchema.csvs"), None).isSuccess mustEqual true
     }
   }
 
   "A fileExists rule" should {
 
-    val schemaPath = Path.fromString(base) / "fileExistsSchema.csvs"
-    val schemaTemplate = schemaPath.lines(includeTerminator = true).mkString
+    val schemaPath = Paths.get(base).resolve("fileExistsSchema.csvs")
+    val schemaTemplate = Files.readAllLines(schemaPath).asScala.mkString
     val schema = schemaTemplate.replace("$$acceptancePath$$", base)
 
     "ensure the file exists on the file system" in {
-      validate(TextFile(Path.fromString(base) / "fileExistsPassMetaData.csv"), parse(new StringReader(schema)), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("fileExistsPassMetaData.csv")), parse(new StringReader(schema)), None).isSuccess mustEqual true
     }
 
     "ensure the file exists on the file system" in {
 
-      val csvPath = Path.fromString(base) / "fileExistsCrossRefPassMetaData.csv"
-      val csvTemplate = csvPath.lines(includeTerminator = true).mkString
+      val csvPath = Paths.get(base).resolve("fileExistsCrossRefPassMetaData.csv")
+      val csvTemplate = Files.readAllLines(csvPath).asScala.mkString
       val csv = csvTemplate.replace("$$acceptancePath$$", base)
 
       validateR(new StringReader(csv), parse(base + "/fileExistsCrossRefSchema.csvs")).isSuccess mustEqual true
     }
 
     "fail if the file does not exist on the file system" in {
-      validate(TextFile(Path.fromString(base) / "fileExistsPassMetaData.csv"), parse(base + "/fileExistsSchemaWithBadBasePath.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("fileExistsPassMetaData.csv")), parse(base + "/fileExistsSchemaWithBadBasePath.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, """fileExists("src/test/resources/uk/gov/nationalarchives") fails for line: 1, column: PasswordFile, value: "benPass.csvs"""",Some(1),Some(2)),
           FailMessage(ValidationError, """fileExists("src/test/resources/uk/gov/nationalarchives") fails for line: 2, column: PasswordFile, value: "andyPass.csvs"""",Some(2),Some(2)))
@@ -321,11 +324,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "enforce case-sensitive comparisons when case-sensitive comparisons are set" in {
 
-      val csfSchemaPath = Path.fromString(base) / "caseSensitiveFiles.csvs"
-      val csfSchemaTemplate = csfSchemaPath.lines(includeTerminator = true).mkString
+      val csfSchemaPath = Paths.get(base).resolve("caseSensitiveFiles.csvs")
+      val csfSchemaTemplate = Files.readAllLines(csfSchemaPath).asScala.mkString
       val csfSchema = csfSchemaTemplate.replace("$$acceptancePath$$", base)
 
-      validateE(TextFile(Path.fromString(base) / "caseSensitiveFiles.csv"), parseE(new StringReader(csfSchema)), None) must beLike {
+      validateE(TextFile(Paths.get(base).resolve("caseSensitiveFiles.csv")), parseE(new StringReader(csfSchema)), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, """fileExists("$$acceptance$$") fails for line: 2, column: filename, value: "casesensitivefiles.csv"""".replace("$$acceptance$$", base),Some(2),Some(0)),
           FailMessage(ValidationError, """fileExists("$$acceptance$$") fails for line: 3, column: filename, value: "CASESENSITIVEFILES.csv"""".replace("$$acceptance$$", base),Some(3),Some(0))
@@ -337,24 +340,24 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
   "A range rule" should {
 
     "enforce all element in a call on to be in a range of value" in {
-      validate(TextFile(Path.fromString(base) / "rangeRulePassMetaData.csv"), parse(base + "/rangeRuleSchema.csvs"), None).isSuccess mustEqual  true
+      validate(TextFile(Paths.get(base).resolve("rangeRulePassMetaData.csv")), parse(base + "/rangeRuleSchema.csvs"), None).isSuccess mustEqual  true
     }
 
     "enforce all element in a call on to be in a range of value" in {
-      validate(TextFile(Path.fromString(base) / "rangeRuleFailMetaData.csv"), parse(base + "/rangeRuleSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("rangeRuleFailMetaData.csv")), parse(base + "/rangeRuleSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """range(1910,*) fails for line: 2, column: Year_of_birth, value: "1909"""",Some(2),Some(1)))
       }
     }
 
     "fail with no limit set" in {
-      parseSchema(TextFile(Path.fromString(base) / "rangeRuleFailSchema.csvs")) must beLike {
+      parseSchema(TextFile(Paths.get(base).resolve("rangeRuleFailSchema.csvs"))) must beLike {
         case Failure(errors) => errors.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: Year_of_birth: Invalid range in 'range(*,*)' at least one value needs to be defined""",None,None))
       }
     }
 
 
     "fail with inconsistent limit" in {
-      parseSchema(TextFile(Path.fromString(base) / "rangeRuleInvalidSchema.csvs")) must beLike {
+      parseSchema(TextFile(Paths.get(base).resolve("rangeRuleInvalidSchema.csvs"))) must beLike {
         case Failure(errors) => errors.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: Year_of_birth: Invalid range, minimum greater than maximum in: 'range(100,1)' at line: 4, column: 16""",None,None))
       }
     }
@@ -364,11 +367,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
     "enforce case-sensitive comparisons when case-sensitive comparisons are set" in {
 
-      val csfSchemaPath = Path.fromString(base) / "caseSensitiveFilesChecksum.csvs"
-      val csfSchemaTemplate = csfSchemaPath.lines(includeTerminator = true).mkString
+      val csfSchemaPath = Paths.get(base).resolve("caseSensitiveFilesChecksum.csvs")
+      val csfSchemaTemplate = Files.readAllLines(csfSchemaPath).asScala.mkString
       val csfSchema = csfSchemaTemplate.replace("$$acceptancePath$$", base)
 
-      validateE(TextFile(Path.fromString(base) / "caseSensitiveFilesChecksum.csv"), parseE(new StringReader(csfSchema)), None) must beLike {
+      validateE(TextFile(Paths.get(base).resolve("caseSensitiveFilesChecksum.csv")), parseE(new StringReader(csfSchema)), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, """checksum(file("$$acceptance$$", $filename), "MD5") file "$$acceptance$$$$file-sep$$casesensitivefileschecksum.csvs" not found for line: 2, column: checksum, value: "41424313f6052b7f062358ed38640b6e"""".replace("$$acceptance$$", base).replace("$$file-sep$$", FILE_SEPARATOR.toString),Some(2),Some(1)),
           FailMessage(ValidationError, """checksum(file("$$acceptance$$", $filename), "MD5") file "$$acceptance$$$$file-sep$$CASESENSITIVEFILESCHECKSUM.csvs" not found for line: 3, column: checksum, value: "41424313f6052b7f062358ed38640b6e"""".replace("$$acceptance$$", base).replace("$$file-sep$$", FILE_SEPARATOR.toString),Some(3),Some(1))
@@ -380,15 +383,15 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
   "A identical rule" should {
 
     "enforce all rows of the same column to be identical between themselves " in {
-      validate(TextFile(Path.fromString(base) / "identicalPassMetaData.csv"), parse(base + "/identicalSchema.csvs"), None).isSuccess mustEqual  true
+      validate(TextFile(Paths.get(base).resolve("identicalPassMetaData.csv")), parse(base + "/identicalSchema.csvs"), None).isSuccess mustEqual  true
     }
 
     "enforce all rows of the same column to be identical between themselves with header" in {
-      validate(TextFile(Path.fromString(base) / "identicalHeaderMetaData.csv"), parse(base + "/identicalHeaderSchema.csvs"), None).isSuccess mustEqual  true
+      validate(TextFile(Paths.get(base).resolve("identicalHeaderMetaData.csv")), parse(base + "/identicalHeaderSchema.csvs"), None).isSuccess mustEqual  true
     }
 
     "fail for different rows in the same column  " in {
-      validateE(TextFile(Path.fromString(base) / "identicalFailMetaData.csv"), parseE(base + "/identicalSchema.csvs"), None) must beLike {
+      validateE(TextFile(Paths.get(base).resolve("identicalFailMetaData.csv")), parseE(base + "/identicalSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, """identical fails for line: 3, column: FullName, value: "fff"""",Some(3),Some(1))
         )
@@ -396,7 +399,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     }
 
     "fail for empty value   " in {
-      validate(TextFile(Path.fromString(base) / "identicalEmptyMetaData.csv"), parse(base + "/identicalSchema.csvs"), None).isFailure mustEqual true
+      validate(TextFile(Paths.get(base).resolve("identicalEmptyMetaData.csv")), parse(base + "/identicalSchema.csvs"), None).isFailure mustEqual true
     }
 
   }
@@ -405,24 +408,24 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     val app = new CsvValidator with FailFastMetaDataValidator  { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false }
 
     "only report first error for invalid @TotalColumns" in {
-      app.validate(TextFile(Path.fromString(base) / "totalColumnsFailMetaData.csv"), parse(base + "/totalColumnsSchema.csvs"), None) must beLike {
+      app.validate(TextFile(Paths.get(base).resolve("totalColumnsFailMetaData.csv")), parse(base + "/totalColumnsSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, "Expected @totalColumns of 1 and found 2 on line 2",Some(2),Some(2)))
       }
     }
 
     "only report first rule fail for multiple rules on a column" in {
-      app.validate(TextFile(Path.fromString(base) / "rulesFailMetaData.csv"), parse(base + "/rulesSchema.csvs"), None) must beLike {
+      app.validate(TextFile(Paths.get(base).resolve("rulesFailMetaData.csv")), parse(base + "/rulesSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """regex("[A-Z][a-z]+") fails for line: 2, column: Name, value: "ben"""",Some(2),Some(0)))
       }
     }
 
     "succeed for multiple rules with valid metadata" in {
-      app.validate(TextFile(Path.fromString(base) / "twoRulesPassMetaData.csv"), parse(base + "/twoRuleSchema.csvs"), None).isSuccess mustEqual true
+      app.validate(TextFile(Paths.get(base).resolve("twoRulesPassMetaData.csv")), parse(base + "/twoRuleSchema.csvs"), None).isSuccess mustEqual true
     }
 
 
     "report warnings" in {
-      app.validate(TextFile(Path.fromString(base) / "warnings.csv"), parse(base + "/warnings.csvs"), None) must beLike {
+      app.validate(TextFile(Paths.get(base).resolve("warnings.csv")), parse(base + "/warnings.csvs"), None) must beLike {
         case Failure(warnings) => warnings.list mustEqual IList(
           FailMessage(ValidationWarning, """is("WO") fails for line: 2, column: department, value: "BT"""", Some(2), Some(0)),
           FailMessage(ValidationWarning, """is("WO") fails for line: 3, column: department, value: "ED"""", Some(3), Some(0))
@@ -431,7 +434,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     }
 
     "report warnings and only first error" in {
-      app.validate(TextFile(Path.fromString(base) / "warningsAndErrors.csv"), parse(base + "/warnings.csvs"), None) must beLike {
+      app.validate(TextFile(Paths.get(base).resolve("warningsAndErrors.csv")), parse(base + "/warnings.csvs"), None) must beLike {
         case Failure(warningsAndError) => warningsAndError.list mustEqual IList(
           FailMessage(ValidationWarning, """is("WO") fails for line: 2, column: department, value: "BT"""", Some(2), Some(0)),
           FailMessage(ValidationWarning, """is("WO") fails for line: 3, column: department, value: "ED"""", Some(3), Some(0)),
@@ -444,37 +447,37 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
   "validate schema" should {
 
     "fail with duplicate column ids" in {
-      parseSchema(TextFile(Path.fromString(base) / "duplicateColumnIdsFailSchema.csvs")) must beLike {
+      parseSchema(TextFile(Paths.get(base).resolve("duplicateColumnIdsFailSchema.csvs"))) must beLike {
         case Failure(errors) => errors.list mustEqual IList(FailMessage(SchemaDefinitionError, """Column: Age has duplicates on lines 3, 8
                                                                            |Column: Country has duplicates on lines 4, 5, 7""".stripMargin))
       }
     }
 
     "fail with unique column ids" in {
-      validate(TextFile(Path.fromString(base) / "duplicateColumnIdsMetaData.csv"), parse(base + "/duplicateColumnIdsPassSchema.csvs"), None).isFailure mustEqual true
+      validate(TextFile(Paths.get(base).resolve("duplicateColumnIdsMetaData.csv")), parse(base + "/duplicateColumnIdsPassSchema.csvs"), None).isFailure mustEqual true
     }
   }
 
   "An 'or' rule" should {
 
     "succeed if either the lhs or rhs succeeds" in {
-      validate(TextFile(Path.fromString(base) / "orWithTwoRulesPassMetaData.csv"), parse(base + "/orWithTwoRulesSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("orWithTwoRulesPassMetaData.csv")), parse(base + "/orWithTwoRulesSchema.csvs"), None) must beLike {
         case Success(_) => ok
       }
     }
 
     "fail if both the lhs or rhs are fail" in {
-      validate(TextFile(Path.fromString(base) / "orWithTwoRulesFailMetaData.csv"), parse(base + "/orWithTwoRulesSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("orWithTwoRulesFailMetaData.csv")), parse(base + "/orWithTwoRulesSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """regex("[A-Z][a-z]+") or regex("[0-9]+") fails for line: 4, column: CountryOrCountryCode, value: "Andromeda9"""",Some(4),Some(1)))
       }
     }
 
     "succeed for 2 'or' rules with an 'and' rule" in {
-      validate(TextFile(Path.fromString(base) / "orWithFourRulesPassMetaData.csv"), parse(base + "/orWithFourRulesSchema.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("orWithFourRulesPassMetaData.csv")), parse(base + "/orWithFourRulesSchema.csvs"), None).isSuccess mustEqual true
     }
 
     "fail if 'or' rules pass and 'and' rule fails" in {
-      validate(TextFile(Path.fromString(base) / "orWithFourRulesFailMetaData.csv"), parse(base + "/orWithFourRulesSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("orWithFourRulesFailMetaData.csv")), parse(base + "/orWithFourRulesSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """regex("[A-Z].+") fails for line: 2, column: Country, value: "ngland"""",Some(2),Some(1)))
       }
     }
@@ -482,11 +485,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "No arg standard rules" should {
     "succeed if all the rules are valid" in {
-      validate(TextFile(Path.fromString(base) / "standardRulesPassMetaData.csv"), parse(base + "/standardRulesSchema.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("standardRulesPassMetaData.csv")), parse(base + "/standardRulesSchema.csvs"), None).isSuccess mustEqual true
     }
 
     "fail if all the rules are not" in {
-      validate(TextFile(Path.fromString(base) / "standardRulesFailMetaData.csv"), parse(base + "/standardRulesSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("standardRulesFailMetaData.csv")), parse(base + "/standardRulesSchema.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(
           FailMessage(ValidationError, """uri fails for line: 1, column: uri, value: "http:##datagov.nationalarchives.gov.uk#66#WO#409#9999#0#aaaaaaaa-aaaa-4aaa-9eee-0123456789ab"""", Some(1), Some(0)),
           FailMessage(ValidationError, """xDateTime fails for line: 1, column: xDateTime, value: "2002-999-30T09:00:10"""", Some(1), Some(1)),
@@ -501,16 +504,16 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
   }
 
   "Schema 1.1 should be backward compatible" in {
-    parseSchema(TextFile(Path.fromString(base + "/rule1_0.csvs"))).isSuccess mustEqual true
+    parseSchema(TextFile(Paths.get(base + "/rule1_0.csvs"))).isSuccess mustEqual true
   }
 
   "No ext string provider" should {
     "should remove filename extension" in {
-      validate(TextFile(Path.fromString(base) / "noextPass.csv"), parse(base + "/noext.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("noextPass.csv")), parse(base + "/noext.csvs"), None).isSuccess mustEqual true
     }
 
     "fail for incorrect extension removal" in {
-      validate(TextFile(Path.fromString(base) / "noextFail.csv"), parse(base + "/noext.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("noextFail.csv")), parse(base + "/noext.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """is(noext($identifier)) fails for line: 3, column: noext, value: "file:/a/b/c.txt"""",Some(3),Some(1)))
       }
     }
@@ -518,37 +521,37 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "Url decode string provider" should {
     "decode url string to normal string" in {
-      validate(TextFile(Path.fromString(base) / "uriDecodePass.csv"), parse(base + "/uriDecode.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("uriDecodePass.csv")), parse(base + "/uriDecode.csvs"), None).isSuccess mustEqual true
     }
 
     "fail for wrong url" in {
-      validate(TextFile(Path.fromString(base) / "uriDecodeFail.csv"), parse(base + "/uriDecode.csvs"), None).isFailure mustEqual true
+      validate(TextFile(Paths.get(base).resolve("uriDecodeFail.csv")), parse(base + "/uriDecode.csvs"), None).isFailure mustEqual true
     }
 
     "decode URL with optional charset parameter" in {
 
-      validate(TextFile(Path.fromString(base) / "uriDecodeWithCharsetPass.csv"), parse(base + "/uriDecodeWithCharset.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("uriDecodeWithCharsetPass.csv")), parse(base + "/uriDecodeWithCharset.csvs"), None).isSuccess mustEqual true
     }
   }
 
   "Concat string provider" should {
     "should concatenate string provider" in {
-      val x = validate(TextFile(Path.fromString(base) / "concatPass.csv"), parse(base + "/concat.csvs"), None)
+      val x = validate(TextFile(Paths.get(base).resolve("concatPass.csv")), parse(base + "/concat.csvs"), None)
       x.isSuccess mustEqual true
     }
 
     "fail for incorrect concatenation" in {
-      validate(TextFile(Path.fromString(base) / "concatFail.csv"), parse(base + "/concat.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("concatFail.csv")), parse(base + "/concat.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """is(concat($c1, $c2)) fails for line: 3, column: c3, value: "ccccc"""",Some(3),Some(2)))
       }
     }
 
     "should concatenate string provider (various arguments)" in {
-      validate(TextFile(Path.fromString(base) / "concat4Pass.csv"), parse(base + "/concat4.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("concat4Pass.csv")), parse(base + "/concat4.csvs"), None).isSuccess mustEqual true
     }
 
     "fail for incorrect concatenation (various arguments)" in {
-      validate(TextFile(Path.fromString(base) / "concat4Fail.csv"), parse(base + "/concat4.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("concat4Fail.csv")), parse(base + "/concat4.csvs"), None) must beLike {
         case Failure(errors) =>  errors.list mustEqual IList(FailMessage(ValidationError, """is(concat($c1, $c2, "hello", $c4)) fails for line: 2, column: c5, value: "aabbccdd"""",Some(2),Some(4)))
       }
     }
@@ -556,11 +559,11 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "Redacted schema" should {
     "should remove filename extension" in {
-      validate(TextFile(Path.fromString(base) / "redactedPass.csv"), parse(base + "/redacted.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("redactedPass.csv")), parse(base + "/redacted.csvs"), None).isSuccess mustEqual true
     }
 
     "fail for incorrect concatenation" in {
-      validate(TextFile(Path.fromString(base) / "redactedFail.csv"), parse(base + "/redacted.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("redactedFail.csv")), parse(base + "/redacted.csvs"), None) must beLike {
         case Failure(errors) => errors.list mustEqual IList(FailMessage(ValidationError, """is(concat(noext($original_identifier), "_R.pdf")) fails for line: 2, column: identifier, value: "file:/some/folder/TNA%20Digital%20Preservation%20Strategy%20v0.3%5BA1031178%5D_R1.pdf"""",Some(2),Some(0)))
       }
     }
@@ -568,7 +571,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "Reader" should {
     "successfully parse byte order marks" in {
-      validate(TextFile(Path.fromString(base) / "bom.csv"), parse(base + "/bom.csvs"), None).isSuccess mustEqual true
+      validate(TextFile(Paths.get(base).resolve("bom.csv")), parse(base + "/bom.csvs"), None).isSuccess mustEqual true
     }
   }
 }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
@@ -298,7 +298,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
   "A fileExists rule" should {
 
     val schemaPath = Paths.get(base).resolve("fileExistsSchema.csvs")
-    val schemaTemplate = Files.readAllLines(schemaPath).asScala.mkString
+    val schemaTemplate = Files.readAllLines(schemaPath).asScala.mkString(EOL)
     val schema = schemaTemplate.replace("$$acceptancePath$$", base)
 
     "ensure the file exists on the file system" in {
@@ -308,7 +308,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     "ensure the file exists on the file system" in {
 
       val csvPath = Paths.get(base).resolve("fileExistsCrossRefPassMetaData.csv")
-      val csvTemplate = Files.readAllLines(csvPath).asScala.mkString
+      val csvTemplate = Files.readAllLines(csvPath).asScala.mkString(EOL)
       val csv = csvTemplate.replace("$$acceptancePath$$", base)
 
       validateR(new StringReader(csv), parse(base + "/fileExistsCrossRefSchema.csvs")).isSuccess mustEqual true
@@ -325,7 +325,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     "enforce case-sensitive comparisons when case-sensitive comparisons are set" in {
 
       val csfSchemaPath = Paths.get(base).resolve("caseSensitiveFiles.csvs")
-      val csfSchemaTemplate = Files.readAllLines(csfSchemaPath).asScala.mkString
+      val csfSchemaTemplate = Files.readAllLines(csfSchemaPath).asScala.mkString(EOL)
       val csfSchema = csfSchemaTemplate.replace("$$acceptancePath$$", base)
 
       validateE(TextFile(Paths.get(base).resolve("caseSensitiveFiles.csv")), parseE(new StringReader(csfSchema)), None) must beLike {
@@ -368,7 +368,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     "enforce case-sensitive comparisons when case-sensitive comparisons are set" in {
 
       val csfSchemaPath = Paths.get(base).resolve("caseSensitiveFilesChecksum.csvs")
-      val csfSchemaTemplate = Files.readAllLines(csfSchemaPath).asScala.mkString
+      val csfSchemaTemplate = Files.readAllLines(csfSchemaPath).asScala.mkString(EOL)
       val csfSchema = csfSchemaTemplate.replace("$$acceptancePath$$", base)
 
       validateE(TextFile(Paths.get(base).resolve("caseSensitiveFilesChecksum.csv")), parseE(new StringReader(csfSchema)), None) must beLike {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorBigFileSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorBigFileSpec.scala
@@ -13,9 +13,10 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import scalaz._
 import uk.gov.nationalarchives.csv.validator.schema.Schema
-import uk.gov.nationalarchives.csv.validator.api.{TextFile, CsvValidator}
-import scalax.file.Path
+import uk.gov.nationalarchives.csv.validator.api.{CsvValidator, TextFile}
 import uk.gov.nationalarchives.csv.validator.api.CsvValidator.SubstitutePath
+
+import java.nio.file.Paths
 
 @RunWith(classOf[JUnitRunner])
 class MetaDataValidatorBigFileSpec extends Specification with TestResources {
@@ -26,16 +27,16 @@ class MetaDataValidatorBigFileSpec extends Specification with TestResources {
 
     "succeed with no stack overflow for all errors" in {
       val v = new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = List[SubstitutePath](); val enforceCaseSensitivePathChecks = false; val trace = false }
-      def parse(filePath: String): Schema = v.parseSchema(TextFile(Path.fromString(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
+      def parse(filePath: String): Schema = v.parseSchema(TextFile(Paths.get(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
 
-      v.validate(TextFile(Path.fromString(base) / "bigMetaData.csv"), parse(base + "/bigSchema.csvs"), None) must beLike { case Success(_) => ok }
+      v.validate(TextFile(Paths.get(base).resolve("bigMetaData.csv")), parse(base + "/bigSchema.csvs"), None) must beLike { case Success(_) => ok }
     }
 
     "succeed with no stack overflow for fail fast" in {
       val v = new CsvValidator with FailFastMetaDataValidator { val pathSubstitutions = List[SubstitutePath](); val enforceCaseSensitivePathChecks = false; val trace = false }
-      def parse(filePath: String): Schema = v.parseSchema(TextFile(Path.fromString(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
+      def parse(filePath: String): Schema = v.parseSchema(TextFile(Paths.get(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
 
-      v.validate(TextFile(Path.fromString(base) / "bigMetaData.csv"), parse(base + "/bigSchema.csvs"), None) must beLike { case Success(_) => ok }
+      v.validate(TextFile(Paths.get(base).resolve("bigMetaData.csv")), parse(base + "/bigSchema.csvs"), None) must beLike { case Success(_) => ok }
     }
   }
 }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorBusinessAcceptanceSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorBusinessAcceptanceSpec.scala
@@ -13,8 +13,9 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import scalaz._
 import uk.gov.nationalarchives.csv.validator.schema.Schema
-import uk.gov.nationalarchives.csv.validator.api.{TextFile, CsvValidator}
-import scalax.file.Path
+import uk.gov.nationalarchives.csv.validator.api.{CsvValidator, TextFile}
+
+import java.nio.file.Paths
 
 @RunWith(classOf[JUnitRunner])
 class MetaDataValidatorBusinessAcceptanceSpec extends Specification with TestResources {
@@ -24,18 +25,18 @@ class MetaDataValidatorBusinessAcceptanceSpec extends Specification with TestRes
   val v: CsvValidator = new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false }
   import v.{validate, parseSchema}
 
-  def parse(filePath: String): Schema = parseSchema(TextFile(Path.fromString(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
+  def parse(filePath: String): Schema = parseSchema(TextFile(Paths.get(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
 
   "Regex rule" should {
 
     "succeed" in {
-      validate(TextFile(Path.fromString(base) / "regexRulePassMetaData.csv"), parse(base + "/regexRuleSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("regexRulePassMetaData.csv")), parse(base + "/regexRuleSchema.csvs"), None) must beLike {
         case Success(_) => ok
       }
     }
 
     "fail" in {
-      validate(TextFile(Path.fromString(base) / "regexRuleFailMetaData.csv"), parse(base + "/regexRuleSchema.csvs"), None) must beLike {
+      validate(TextFile(Paths.get(base).resolve("regexRuleFailMetaData.csv")), parse(base + "/regexRuleSchema.csvs"), None) must beLike {
         case Failure(_) => ok
       }
     }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorIntegrityCheckSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorIntegrityCheckSpec.scala
@@ -12,10 +12,10 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.api.{CsvValidator, TextFile}
-import uk.gov.nationalarchives.csv.validator.schema.{TraceableParsers, Schema}
+import uk.gov.nationalarchives.csv.validator.schema.Schema
+import scalaz.Failure
 
-import scalax.file.Path
-import scalaz.{Failure, Success}
+import java.nio.file.Paths
 
 @RunWith(classOf[JUnitRunner])
 class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResources {
@@ -26,7 +26,7 @@ class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResourc
     val trace = false
   }
 
-  def parse(filePath: String, validator: CsvValidator): Schema = validator.parseSchema(TextFile(Path.fromString(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
+  def parse(filePath: String, validator: CsvValidator): Schema = validator.parseSchema(TextFile(Paths.get(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
 
   "integrity Check" should {
     val headerPath = integrityCheckPath + "/header/"
@@ -38,7 +38,7 @@ class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResourc
 
       val substitutionPaths = List(("file:///T:/WORK/RF_5/",headerPath))
       val validator = buildValidator(substitutionPaths)
-      validator.validate(TextFile(Path.fromString(headerPath) / "integrityCheckMetaData.csv"), parse(headerPath + "/integrityCheckSchema.csvs",validator), None).isSuccess mustEqual true
+      validator.validate(TextFile(Paths.get(headerPath).resolve("integrityCheckMetaData.csv")), parse(headerPath + "/integrityCheckSchema.csvs",validator), None).isSuccess mustEqual true
 
 
     }
@@ -47,7 +47,7 @@ class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResourc
 
       val substitutionPaths = List(("file:///T:/WORK/RF_5/",headerPath))
       val validator = buildValidator(substitutionPaths)
-      validator.validate(TextFile(Path.fromString(headerPath) / "integrityCheckMetaData.csv"), parse(headerPath + "/integrityCheckDefaultIncludeFolderSchema.csvs",validator), None).isSuccess mustEqual true
+      validator.validate(TextFile(Paths.get(headerPath).resolve("integrityCheckMetaData.csv")), parse(headerPath + "/integrityCheckDefaultIncludeFolderSchema.csvs",validator), None).isSuccess mustEqual true
 
     }
 
@@ -57,7 +57,7 @@ class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResourc
       val substitutionPaths = List(("file:///T:/WORK/RF_5/",headerPath))
       //      val validator = buildValidator(substitutionPaths, Some("filename"))
       val validator = buildValidator(substitutionPaths)
-      val result = validator.validate(TextFile(Path.fromString(headerPath) / "integrityCheckMetaData-missing-files.csv"), parse(headerPath + "/integrityCheckSchema.csvs",validator), None)
+      val result = validator.validate(TextFile(Paths.get(headerPath).resolve("integrityCheckMetaData-missing-files.csv")), parse(headerPath + "/integrityCheckSchema.csvs",validator), None)
 
       result.isFailure mustEqual true
       val Failure(message) = result
@@ -70,7 +70,7 @@ class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResourc
 
       val substitutionPaths = List(("file:///T:/WORK/RF_5/",headerPath))
       val validator = buildValidator(substitutionPaths)
-      val result = validator.validate(TextFile(Path.fromString(headerPath) / "integrityCheckMetaData-missing-files.csv"), parse(headerPath + "/integrityCheckSchema.csvs",validator), None)
+      val result = validator.validate(TextFile(Paths.get(headerPath).resolve("integrityCheckMetaData-missing-files.csv")), parse(headerPath + "/integrityCheckSchema.csvs",validator), None)
 
       result.isFailure mustEqual true
       val Failure(message) = result
@@ -85,7 +85,7 @@ class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResourc
       val substitutionPaths = List(("file:///T:/WORK/RF_5/",noHeaderPath))
       val validator = buildValidator(substitutionPaths)
       val schema: Schema = parse(noHeaderPath + "/integrityCheckSchema.csvs", validator)
-      validator.validate(TextFile(Path.fromString(noHeaderPath) / "integrityCheckMetaData.csv"), schema, None).isSuccess mustEqual true
+      validator.validate(TextFile(Paths.get(noHeaderPath).resolve("integrityCheckMetaData.csv")), schema, None).isSuccess mustEqual true
 
     }
 
@@ -94,7 +94,7 @@ class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResourc
 
       val substitutionPaths = List(("file:///T:/WORK/RF_5/",noHeaderPath))
       val validator = buildValidator(substitutionPaths)
-      val result = validator.validate(TextFile(Path.fromString(noHeaderPath) / "integrityCheckMetaData.csv"), parse(noHeaderPath + "/badIntegrityCheckSchema.csvs",validator), None)
+      val result = validator.validate(TextFile(Paths.get(noHeaderPath).resolve("integrityCheckMetaData.csv")), parse(noHeaderPath + "/badIntegrityCheckSchema.csvs",validator), None)
       result.isFailure mustEqual true
       val Failure(message) = result
       // println(message)
@@ -105,14 +105,14 @@ class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResourc
 
       val substitutionPaths = List(("file:///WO_95",WO95Path))
       val validator = buildValidator(substitutionPaths)
-      validator.validate(TextFile(Path.fromString(WO95Path) / "tech_acq_metadata_v1_WO95Y14B003.csv"), parse(WO95Path + "/tech_acq_metadata_v1_WO95Y14B000.csvs",validator), None).isSuccess mustEqual true
+      validator.validate(TextFile(Paths.get(WO95Path).resolve("tech_acq_metadata_v1_WO95Y14B003.csv")), parse(WO95Path + "/tech_acq_metadata_v1_WO95Y14B000.csvs",validator), None).isSuccess mustEqual true
     }
 
     "Validate WO 95 with 1.2 schema version to test backward compatibility" in {
 
       val substitutionPaths = List(("file:///WO_95",WO95Path))
       val validator = buildValidator(substitutionPaths)
-      validator.validate(TextFile(Path.fromString(WO95Path) / "tech_acq_metadata_v1_WO95Y14B003.csv"), parse(WO95Path + "/tech_acq_metadata_v1_WO95Y14B000_v1.2.csvs",validator), None).isSuccess mustEqual true
+      validator.validate(TextFile(Paths.get(WO95Path).resolve("tech_acq_metadata_v1_WO95Y14B003.csv")), parse(WO95Path + "/tech_acq_metadata_v1_WO95Y14B000_v1.2.csvs",validator), None).isSuccess mustEqual true
     }
 
 
@@ -122,15 +122,15 @@ class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResourc
 
 
       val validator = buildValidator(substitutionPaths)
-      validator.validate(TextFile(Path.fromString(headerPath) / "integrityCheckMetaData.csv"), parse(headerPath + "/integrityCheckSchema.csvs",validator), None).isSuccess mustEqual true
+      validator.validate(TextFile(Paths.get(headerPath).resolve("integrityCheckMetaData.csv")), parse(headerPath + "/integrityCheckSchema.csvs",validator), None).isSuccess mustEqual true
 
       val substitutionPaths2 = List(("file:///T:/WORK/RF_5/content/",headerPath + "content/"))
       val validator2 = buildValidator(substitutionPaths2)
-      validator2.validate(TextFile(Path.fromString(headerPath) / "integrityCheckMetaData.csv"), parse(headerPath + "/integrityCheckSchema.csvs",validator), None).isSuccess mustEqual true
+      validator2.validate(TextFile(Paths.get(headerPath).resolve("integrityCheckMetaData.csv")), parse(headerPath + "/integrityCheckSchema.csvs",validator), None).isSuccess mustEqual true
 
       val substitutionPaths3 = List(("file:///T:/WORK/RF_5/content/",headerPath + "content"))
       val validator3 = buildValidator(substitutionPaths3)
-      validator3.validate(TextFile(Path.fromString(headerPath) / "integrityCheckMetaData.csv"), parse(headerPath + "/integrityCheckSchema.csvs",validator), None).isSuccess mustEqual true
+      validator3.validate(TextFile(Paths.get(headerPath).resolve("integrityCheckMetaData.csv")), parse(headerPath + "/integrityCheckSchema.csvs",validator), None).isSuccess mustEqual true
     }
 
     "safely fail with incorrect substitution paths - header" in {
@@ -138,7 +138,7 @@ class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResourc
       val substitutionPaths = List(("file:///T:/WORK/RF_5/content123",headerPath + "content123"))
 
       val validator = buildValidator(substitutionPaths)
-      validator.validate(TextFile(Path.fromString(headerPath) / "integrityCheckMetaData.csv"), parse(headerPath + "/integrityCheckSchema.csvs",validator), None).isFailure mustEqual true
+      validator.validate(TextFile(Paths.get(headerPath).resolve("integrityCheckMetaData.csv")), parse(headerPath + "/integrityCheckSchema.csvs",validator), None).isFailure mustEqual true
 
     }
 
@@ -146,7 +146,7 @@ class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResourc
 
         val substitutionPaths = List(("file:///T:/WORK/RF_5", contentPath))
         val validator = buildValidator(substitutionPaths)
-        validator.validate(TextFile(Path.fromString(contentPath) / "integrityCheckMetaData.csv"), parse(contentPath + "/integrityCheckSchema.csvs",validator), None).isSuccess mustEqual true
+        validator.validate(TextFile(Paths.get(contentPath).resolve("integrityCheckMetaData.csv")), parse(contentPath + "/integrityCheckSchema.csvs",validator), None).isSuccess mustEqual true
       }
   }
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/TestResources.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/TestResources.scala
@@ -8,8 +8,9 @@
  */
 package uk.gov.nationalarchives.csv.validator
 
-import java.io.File
 import org.specs2.mutable.Specification
+
+import java.nio.file.Paths
 
 trait TestResources {
 
@@ -21,18 +22,18 @@ trait TestResources {
    *
    * @param resource The path of the resource relative to the spec test
    */
-  def resourcePath(resource: String) : String = new File(baseResourcePkgPath, resource).getAbsolutePath
+  def resourcePath(resource: String) : String = Paths.get(baseResourcePkgPath).resolve(resource).toAbsolutePath.toString
 
-  def baseResourcePkgPath : String = new File(basePath, spec.getClass.getPackage.getName.replace('.', '/')).getAbsolutePath
+  def baseResourcePkgPath : String = Paths.get(basePath).resolve(spec.getClass.getPackage.getName.replace('.', '/')).toAbsolutePath.toString
 
   def basePath : String = {
     val url = spec.getClass.getClassLoader.getResource(".")
-    new File(url.toURI).getAbsolutePath
+    Paths.get(url.toURI).toAbsolutePath.toString
   }
 
   def relBasePath : String = basePath.replace(System.getProperty("user.dir") + FILE_SEPARATOR, "")
-  def relBaseResourcePkgPath : String = new File(relBasePath, spec.getClass.getPackage.getName.replace('.', '/')).getPath
-  def relResourcePath(resource: String) : String = new File(relBaseResourcePkgPath, resource).getPath
+  def relBaseResourcePkgPath : String = Paths.get(relBasePath).resolve(spec.getClass.getPackage.getName.replace('.', '/')).toString
+  def relResourcePath(resource: String) : String = Paths.get(relBaseResourcePkgPath).resolve(resource).toString
 
   def toUriPath(path: String) = path.replace('\\', '/')
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/UtilSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/UtilSpec.scala
@@ -8,11 +8,11 @@
  */
 package uk.gov.nationalarchives.csv.validator
 
-import java.io.File
-
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
+
+import java.nio.file.Paths
 
 @RunWith(classOf[JUnitRunner])
 class UtilSpec extends Specification with TestResources  {
@@ -51,46 +51,46 @@ class UtilSpec extends Specification with TestResources  {
     
     "list file in folder" in {
 
-      val apiFiles = Util.findAllFiles(true, new File(acceptancePath))
+      val apiFiles = Util.findAllFiles(true, Paths.get(acceptancePath))
 
       apiFiles must haveLength(127)
 
-      apiFiles must contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/acceptance/twoRulesPassMetaData.csv"))
+      apiFiles must contain (Paths.get(s"$basePath/uk/gov/nationalarchives/csv/validator/acceptance/twoRulesPassMetaData.csv"))
 
-      apiFiles must contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/acceptance/dp/regexRuleSchema.csvs"))
+      apiFiles must contain (Paths.get(s"$basePath/uk/gov/nationalarchives/csv/validator/acceptance/dp/regexRuleSchema.csvs"))
 
-      apiFiles must contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/acceptance/dp"))
+      apiFiles must contain (Paths.get(s"$basePath/uk/gov/nationalarchives/csv/validator/acceptance/dp"))
 
-      apiFiles must contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/acceptance"))
+      apiFiles must contain (Paths.get(s"$basePath/uk/gov/nationalarchives/csv/validator/acceptance"))
 
-      val integrityCheckFiles =  Util.findAllFiles(true, new File(base))
+      val integrityCheckFiles =  Util.findAllFiles(true, Paths.get(base))
 
       integrityCheckFiles  must haveLength(43)
 
-      integrityCheckFiles must contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/header/integrityCheckSchema.csvs"))
+      integrityCheckFiles must contain (Paths.get(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/header/integrityCheckSchema.csvs"))
 
-      integrityCheckFiles must contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/header/content/file1"))
+      integrityCheckFiles must contain (Paths.get(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/header/content/file1"))
 
-      integrityCheckFiles must contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/header/content"))
+      integrityCheckFiles must contain (Paths.get(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/header/content"))
 
 
-      integrityCheckFiles must contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/noheader/content"))
+      integrityCheckFiles must contain (Paths.get(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/noheader/content"))
 
-      integrityCheckFiles must contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/WO_95/content"))
+      integrityCheckFiles must contain (Paths.get(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/WO_95/content"))
 
-      integrityCheckFiles must contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck"))
+      integrityCheckFiles must contain (Paths.get(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck"))
 
-      val integrityCheckFilesNoFolder =  Util.findAllFiles(false, new File(base))
+      val integrityCheckFilesNoFolder =  Util.findAllFiles(false, Paths.get(base))
 
       integrityCheckFilesNoFolder  must haveLength(29)
 
-      integrityCheckFilesNoFolder must contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/header/content/file1"))
+      integrityCheckFilesNoFolder must contain (Paths.get(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/header/content/file1"))
 
-      integrityCheckFilesNoFolder must contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/header/integrityCheckSchema.csvs"))
+      integrityCheckFilesNoFolder must contain (Paths.get(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/header/integrityCheckSchema.csvs"))
 
-      integrityCheckFilesNoFolder must not contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/noheader/content"))
+      integrityCheckFilesNoFolder must not contain (Paths.get(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/noheader/content"))
 
-      integrityCheckFilesNoFolder must not contain (new File(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/WO_95/content"))
+      integrityCheckFilesNoFolder must not contain (Paths.get(s"$basePath/uk/gov/nationalarchives/csv/validator/integrityCheck/WO_95/content"))
 
 
     }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorFileEncodingSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorFileEncodingSpec.scala
@@ -12,12 +12,11 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import uk.gov.nationalarchives.csv.validator.TestResources
-import org.specs2.mutable.Specification
 import scalaz._
-import uk.gov.nationalarchives.csv.validator.{TestResources, EOL, AllErrorsMetaDataValidator}
+import uk.gov.nationalarchives.csv.validator.AllErrorsMetaDataValidator
 import uk.gov.nationalarchives.csv.validator.schema.Schema
-import scalax.file.Path
-import uk.gov.nationalarchives.csv.validator.api.CsvValidator.SubstitutePath
+
+import java.nio.file.Paths
 
 /**
  * Created by rhubner on 11/12/15.
@@ -28,17 +27,17 @@ class CsvValidatorFileEncodingSpec extends Specification with TestResources {
   "Validation" should {
 
     val app = new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false }
-    def parse(filePath: String): Schema = app.parseSchema(TextFile(Path.fromString(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
+    def parse(filePath: String): Schema = app.parseSchema(TextFile(Paths.get(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
 
     "fail for non UTF-8 file" in {
-      app.validate(TextFile(Path.fromString(baseResourcePkgPath) / "windows-1252.csv"), parse(baseResourcePkgPath + "/schema.csvs"), None) must beLike {
+      app.validate(TextFile(Paths.get(baseResourcePkgPath).resolve("windows-1252.csv")), parse(baseResourcePkgPath + "/schema.csvs"), None) must beLike {
         case Failure(_) => ok
       }
     }
 
 
     "not fail for valid UTF-8 file" in {
-      app.validate(TextFile(Path.fromString(baseResourcePkgPath) / "metaData.csv"), parse(baseResourcePkgPath + "/schema.csvs"), None) must beLike {
+      app.validate(TextFile(Paths.get(baseResourcePkgPath).resolve("metaData.csv")), parse(baseResourcePkgPath + "/schema.csvs"), None) must beLike {
         case Success(_) => ok
       }
     }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorSpec.scala
@@ -38,7 +38,6 @@ class CsvValidatorSpec extends Specification with TestResources {
           "[3.7] failure: Invalid column definition" + EOL
           + EOL
           + """Name: regox("A")""" + EOL
-          + EOL
           + "      ^"))
       }
     }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorSpec.scala
@@ -15,8 +15,9 @@ import org.specs2.runner.JUnitRunner
 import scalaz._
 import uk.gov.nationalarchives.csv.validator._
 import uk.gov.nationalarchives.csv.validator.schema.Schema
-import scalax.file.Path
 import uk.gov.nationalarchives.csv.validator.api.CsvValidator.SubstitutePath
+
+import java.nio.file.Paths
 
 @RunWith(classOf[JUnitRunner])
 class CsvValidatorSpec extends Specification with TestResources {
@@ -46,16 +47,16 @@ class CsvValidatorSpec extends Specification with TestResources {
   "Validation" should {
     val app = new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false }
 
-    def parse(filePath: String): Schema = app.parseSchema(TextFile(Path.fromString(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
+    def parse(filePath: String): Schema = app.parseSchema(TextFile(Paths.get(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
 
     "succeed for valid schema and metadata file" in {
-      app.validate(TextFile(Path.fromString(baseResourcePkgPath) / "metaData.csv"), parse(baseResourcePkgPath + "/schema.csvs"), None) must beLike {
+      app.validate(TextFile(Paths.get(baseResourcePkgPath).resolve("metaData.csv")), parse(baseResourcePkgPath + "/schema.csvs"), None) must beLike {
         case Success(_) => ok
       }
     }
 
     "succeed for valid @totalColumns in schema and metadata file" in {
-      app.validate(TextFile(Path.fromString(baseResourcePkgPath) / "metaData.csv"), parse(baseResourcePkgPath + "/schema.csvs"), None) must beLike {
+      app.validate(TextFile(Paths.get(baseResourcePkgPath).resolve("metaData.csv")), parse(baseResourcePkgPath + "/schema.csvs"), None) must beLike {
         case Success(_) => ok
       }
     }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/FileCountSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/FileCountSpec.scala
@@ -29,36 +29,37 @@ class FileCountSpec extends Specification with TestResources {
   val relThreeFilesPath = relResourcePath("../../fileCountTestFiles/threeFiles")
   val relThreeFilesInSubDirPath = relResourcePath("../../fileCountTestFiles/threeFilesinSubDir")
 
-  "File wildcards selection" should {
-
-    "count multiple files in single directory using wildcards" in {
-      val rootPath = Paths.get(threeFilesPath)
-      val scalaFiles = rootPath.matcher("**/*.jp2")
-
-      rootPath.descendants().collect{ case s @ scalaFiles(_) => s }.size mustEqual 3
-    }
-
-    "count multiple files in subdirectories using wildcards" in {
-      val rootPath = Paths.get(threeFilesInSubDirPath)
-      val scalaFiles = rootPath.matcher("**/*.jp2")
-
-      rootPath.descendants().collect{ case s @ scalaFiles(_) => s }.size mustEqual 3
-    }
-
-    "count multiple files in subdirectories, using wildcards" in {
-      val rootPath = Paths.get(threeFilesInSubDirPath)
-      val scalaFiles = rootPath.matcher("**/file*a.jp2")
-
-      rootPath.descendants().collect{ case s @ scalaFiles(_) => s }.size mustEqual 3
-    }
-
-    "count files without looking in subdirectories, NO wildcards" in {
-      val rootPath = Paths.get(threeFilesInSubDirPath)
-      val scalaFiles = rootPath.matcher("**/file1a.jp2")
-
-      rootPath.descendants().collect{ case s @ scalaFiles(_) => s }.size mustEqual 1
-    }
-  }
+  //TODO(AR) disabled these tests as they seem to be testing the scalax.file.Path library rather than CSV Validator code
+//  "File wildcards selection" should {
+//
+//    "count multiple files in single directory using wildcards" in {
+//      val rootPath = Paths.get(threeFilesPath)
+//      val scalaFiles = rootPath.matcher("**/*.jp2")
+//
+//      rootPath.descendants().collect{ case s @ scalaFiles(_) => s }.size mustEqual 3
+//    }
+//
+//    "count multiple files in subdirectories using wildcards" in {
+//      val rootPath = Paths.get(threeFilesInSubDirPath)
+//      val scalaFiles = rootPath.matcher("**/*.jp2")
+//
+//      rootPath.descendants().collect{ case s @ scalaFiles(_) => s }.size mustEqual 3
+//    }
+//
+//    "count multiple files in subdirectories, using wildcards" in {
+//      val rootPath = Paths.get(threeFilesInSubDirPath)
+//      val scalaFiles = rootPath.matcher("**/file*a.jp2")
+//
+//      rootPath.descendants().collect{ case s @ scalaFiles(_) => s }.size mustEqual 3
+//    }
+//
+//    "count files without looking in subdirectories, NO wildcards" in {
+//      val rootPath = Paths.get(threeFilesInSubDirPath)
+//      val scalaFiles = rootPath.matcher("**/file1a.jp2")
+//
+//      rootPath.descendants().collect{ case s @ scalaFiles(_) => s }.size mustEqual 1
+//    }
+//  }
 
   "fileCount" should {
     "find a match on a directory" in {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/FileWildcardSearchSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/FileWildcardSearchSpec.scala
@@ -11,9 +11,9 @@ package uk.gov.nationalarchives.csv.validator.schema.v1_0
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-
-import scalax.file.{Path, PathSet}
 import scalaz._
+
+import java.nio.file.Path
 
 @RunWith(classOf[JUnitRunner])
 class FileWildcardSearchSpec extends Specification {
@@ -23,7 +23,7 @@ class FileWildcardSearchSpec extends Specification {
 
     val pathSubstitutions = List.empty
     def matchSimplePath(fullPath : String) : ValidationNel[String, Int] = 0.successNel[String]
-    def matchWildcardPaths(matchList: PathSet[Path], fullPath: String): ValidationNel[String, Int] = 0.successNel[String]
+    def matchWildcardPaths(matchList: Seq[Path], fullPath: String): ValidationNel[String, Int] = 0.successNel[String]
 
     def findBaseWrapper(path: String) : (String, String) = {
       val result = super.findBase(path)

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserColumnDirectivesSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserColumnDirectivesSpec.scala
@@ -75,7 +75,6 @@ class SchemaParserColumnDirectivesSpec extends SchemaSpecBase {
         """[3.33] failure: `warning' expected but `i' found
           |
           |column1: @ignoreCase @optional @ignoreCase @optional
-          |
           |                                ^""".stripMargin)) }
     }
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserColumnDirectivesSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserColumnDirectivesSpec.scala
@@ -46,7 +46,7 @@ class SchemaParserColumnDirectivesSpec extends SchemaSpecBase {
                      |column1: @ignoreCase @ignoreCase""".stripMargin
 
       parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError,
-        """[3.23] failure: `warning' expected but `i' found
+        """[3.23] failure: Invalid column definition
         |
         |column1: @ignoreCase @ignoreCase
         |                      ^""".stripMargin)) }
@@ -58,7 +58,7 @@ class SchemaParserColumnDirectivesSpec extends SchemaSpecBase {
                      |column1: @ignoreCase @optional @ignoreCase @optional""".stripMargin
 
       parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError,
-       """[3.33] failure: `warning' expected but `i' found
+       """[3.33] failure: Invalid column definition
        |
        |column1: @ignoreCase @optional @ignoreCase @optional
        |                                ^""".stripMargin)) }
@@ -72,7 +72,7 @@ class SchemaParserColumnDirectivesSpec extends SchemaSpecBase {
                      |column3: @ignoreCase @ignoreCase @optional @optional""".stripMargin
 
       parseAndValidate(new StringReader(schema)) must beLike { case FailureZ(msgs) => msgs.list mustEqual IList(FailMessage(SchemaDefinitionError,
-        """[3.33] failure: `warning' expected but `i' found
+        """[3.33] failure: Invalid column definition
           |
           |column1: @ignoreCase @optional @ignoreCase @optional
           |                                ^""".stripMargin)) }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserRulesSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserRulesSpec.scala
@@ -53,7 +53,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                       Age:"""
 
       parse(new StringReader(schema)) must beLike {
-        case Failure(message, _) => message mustEqual """regex not correctly delimited as ("your regex")"""
+        case Failure(message, _) => message mustEqual """Invalid column definition"""
       }
     }
 
@@ -62,7 +62,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                       @totalColumns 1
                       Something: regex"""
 
-      parse(new StringReader(schema)) must beLike { case Failure(message, _) => (message mustEqual "regex not correctly delimited as (\"your regex\")") }
+      parse(new StringReader(schema)) must beLike { case Failure(message, _) => (message mustEqual "Invalid column definition") }
     }
 
     "succeed for more than 1 regex rule" in {
@@ -143,9 +143,8 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
            @totalColumns 1
            Country: in("UK") or"""
 
-
 //        parse(new StringReader(schema)) must beLike { case Failure(error, _) => error mustEqual "`switch(' expected but end of source found" }
-      parse(new StringReader(schema)) must beLike { case Failure("Base Failure", _) => ok } //TODO(AR) it is not clear why we get a `Base Failure` see http://stackoverflow.com/questions/29300925/scala-packratparser-ignores-failure-parser
+      parse(new StringReader(schema)) must beLike { case Failure("Invalid column definition", _) => ok }
 
     }
 

--- a/csv-validator-java-api/pom.xml
+++ b/csv-validator-java-api/pom.xml
@@ -126,14 +126,8 @@
             <artifactId>scalaz-core_${scala.compat.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.scala-incubator.io</groupId>
-            <artifactId>scala-io-file_${scala.compat.version}</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.scala-lang.modules</groupId>
-                    <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.madgag</groupId>
+            <artifactId>scala-io-file_${scala.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/csv-validator-java-api/pom.xml
+++ b/csv-validator-java-api/pom.xml
@@ -123,11 +123,7 @@
         </dependency>
         <dependency>
             <groupId>org.scalaz</groupId>
-            <artifactId>scalaz-core_${scala.compat.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.madgag</groupId>
-            <artifactId>scala-io-file_${scala.version}</artifactId>
+            <artifactId>scalaz-core_${scala.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/csv-validator-java-api/pom.xml
+++ b/csv-validator-java-api/pom.xml
@@ -128,6 +128,12 @@
         <dependency>
             <groupId>com.github.scala-incubator.io</groupId>
             <artifactId>scala-io-file_${scala.compat.version}</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.scala-lang.modules</groupId>
+                    <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/csv-validator-java-api/src/main/scala/uk/gov/nationalarchives/csv/validator/api/java/CsvValidatorJavaBridge.scala
+++ b/csv-validator-java-api/src/main/scala/uk/gov/nationalarchives/csv/validator/api/java/CsvValidatorJavaBridge.scala
@@ -90,7 +90,7 @@ object CsvValidatorJavaBridge {
 
   private def validate(csvData: JReader, csvSchema: JReader, failFast: Boolean, pathSubstitutionsList: JList[Substitution],  enforceCaseSensitivePathChecks: Boolean, trace: Boolean, progress: Option[SProgressCallback]): JList[FailMessage] = {
 
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     val pathSubs: List[(String,String)] = pathSubstitutionsList.asScala.map( x => (x.getFrom, x.getTo)).toList
 

--- a/csv-validator-java-api/src/main/scala/uk/gov/nationalarchives/csv/validator/api/java/CsvValidatorJavaBridge.scala
+++ b/csv-validator-java-api/src/main/scala/uk/gov/nationalarchives/csv/validator/api/java/CsvValidatorJavaBridge.scala
@@ -8,15 +8,17 @@
  */
 package uk.gov.nationalarchives.csv.validator.api.java
 
-import java.util.{List => JList, ArrayList => JArrayList}
-import scalax.file.Path
-import scalaz.{Success => SuccessZ, Failure => FailureZ, _}
-import uk.gov.nationalarchives.csv.validator.{ProgressCallback => SProgressCallback, FailMessage => SFailMessage, SchemaDefinitionError, ValidationError, ValidationWarning}
+import java.util.{ArrayList => JArrayList, List => JList}
+import scalaz.{Failure => FailureZ, Success => SuccessZ, _}
+import uk.gov.nationalarchives.csv.validator.{SchemaDefinitionError, ValidationError, ValidationWarning, FailMessage => SFailMessage, ProgressCallback => SProgressCallback}
 import uk.gov.nationalarchives.csv.validator.Util._
 import uk.gov.nationalarchives.csv.validator.api.CsvValidator.createValidator
+
 import java.io.{Reader => JReader}
 import uk.gov.nationalarchives.csv.validator.api.TextFile
+
 import java.nio.charset.Charset
+import java.nio.file.Paths
 
 /**
  * Simple bridge from Java API to Scala API
@@ -49,12 +51,12 @@ object CsvValidatorJavaBridge {
 
   private def validate(csvFile: String, csvEncoding: Charset, validateCsvEncoding: Boolean, csvSchemaFile: String, csvSchemaEncoding: Charset, validateCsvSchemaEncoding: Boolean, failFast: Boolean, pathSubstitutionsList: JList[Substitution], enforceCaseSensitivePathChecks: Boolean, trace: Boolean, progress: Option[SProgressCallback]): JList[FailMessage] = {
 
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     val pathSubs: List[(String,String)] = pathSubstitutionsList.asScala.map( x => (x.getFrom, x.getTo)).toList
 
-    val csvTextFile = TextFile(Path.fromString(csvFile), csvEncoding, validateCsvEncoding)
-    val csvSchemaTextFile = TextFile(Path.fromString(csvSchemaFile), csvSchemaEncoding, validateCsvSchemaEncoding)
+    val csvTextFile = TextFile(Paths.get(csvFile), csvEncoding, validateCsvEncoding)
+    val csvSchemaTextFile = TextFile(Paths.get(csvSchemaFile), csvSchemaEncoding, validateCsvSchemaEncoding)
 
     checkFilesReadable(csvTextFile.file :: csvSchemaTextFile.file :: Nil) match {
       case FailureZ(errors) =>

--- a/csv-validator-parent/pom.xml
+++ b/csv-validator-parent/pom.xml
@@ -81,10 +81,10 @@
   </scm>
 
     <properties>
-        <scala.version>2.12</scala.version>
-        <scala.lib.version>2.12.3</scala.lib.version>
+        <scala.version>2.13</scala.version>
+        <scala.lib.version>2.13.8</scala.lib.version>
         <scalaz.version>7.2.30</scalaz.version>
-        <specs2.version>3.8.6</specs2.version>
+        <specs2.version>4.13.2</specs2.version>
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <contact.email>digitalpreservation@nationalarchives.gov.uk</contact.email>
@@ -110,12 +110,15 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>3.4.6</version>
+                    <version>4.5.6</version>
+                    <configuration>
+                        <scalaVersion>${scala.lib.version}</scalaVersion>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.9.0</version>
                 </plugin>
                 <plugin>
                     <groupId>com.code54.mojo</groupId>
@@ -130,7 +133,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.2.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -150,7 +153,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -339,49 +342,34 @@
             <dependency>
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-library</artifactId>
-                <version>${scala.version}</version>
+                <version>${scala.lib.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.scalaz</groupId>
-                <artifactId>scalaz-core_${scala.compat.version}</artifactId>
+                <artifactId>scalaz-core_${scala.version}</artifactId>
                 <version>${scalaz.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.madgag</groupId>
-                <artifactId>scala-io-file_${scala.version}</artifactId>
-                <version>0.4.9</version>
-            </dependency>
-            <dependency>
-                <groupId>com.madgag</groupId>
-                <artifactId>scala-io-core_${scala.version}</artifactId>
-                <version>0.4.9</version>
-            </dependency>
-            <dependency>
-                <groupId>com.michaelpollmeier</groupId>
-                <artifactId>scala-arm_${scala.version}</artifactId>
-                <version>2.1</version>
-            </dependency>
-            <dependency>
                 <groupId>org.specs2</groupId>
-                <artifactId>specs2-core_${scala.compat.version}</artifactId>
+                <artifactId>specs2-core_${scala.version}</artifactId>
                 <version>${specs2.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.specs2</groupId>
-                <artifactId>specs2-common_${scala.compat.version}</artifactId>
+                <artifactId>specs2-common_${scala.version}</artifactId>
                 <version>${specs2.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.specs2</groupId>
-                <artifactId>specs2-matcher_${scala.compat.version}</artifactId>
+                <artifactId>specs2-matcher_${scala.version}</artifactId>
                 <version>${specs2.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.specs2</groupId>
-                <artifactId>specs2-junit_${scala.compat.version}</artifactId>
+                <artifactId>specs2-junit_${scala.version}</artifactId>
                 <version>${specs2.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/csv-validator-parent/pom.xml
+++ b/csv-validator-parent/pom.xml
@@ -83,7 +83,7 @@
     <properties>
         <scala.version>2.13</scala.version>
         <scala.lib.version>2.13.8</scala.lib.version>
-        <scalaz.version>7.2.30</scalaz.version>
+        <scalaz.version>7.2.34</scalaz.version>
         <specs2.version>4.13.2</specs2.version>
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/csv-validator-parent/pom.xml
+++ b/csv-validator-parent/pom.xml
@@ -110,7 +110,7 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>4.4.0</version>
+                    <version>3.4.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -150,7 +150,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.3.2</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/csv-validator-parent/pom.xml
+++ b/csv-validator-parent/pom.xml
@@ -81,11 +81,11 @@
   </scm>
 
     <properties>
-        <scala.compat.version>2.11</scala.compat.version>
-        <scala.version>2.11.12</scala.version>
+        <scala.version>2.12</scala.version>
+        <scala.lib.version>2.12.3</scala.lib.version>
         <scalaz.version>7.2.30</scalaz.version>
-        <specs2.version>3.7.1</specs2.version>
-        <java.version>1.7</java.version>
+        <specs2.version>3.8.6</specs2.version>
+        <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <contact.email>digitalpreservation@nationalarchives.gov.uk</contact.email>
 
@@ -347,19 +347,19 @@
                 <version>${scalaz.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.scala-incubator.io</groupId>
-                <artifactId>scala-io-file_${scala.compat.version}</artifactId>
-                <version>0.4.3-1</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.scala-incubator.io</groupId>
-                <artifactId>scala-io-core_${scala.compat.version}</artifactId>
-                <version>0.4.3-1</version>
+                <groupId>com.madgag</groupId>
+                <artifactId>scala-io-file_${scala.version}</artifactId>
+                <version>0.4.9</version>
             </dependency>
             <dependency>
                 <groupId>com.madgag</groupId>
-                <artifactId>scala-arm_${scala.compat.version}</artifactId>
-                <version>1.3.4</version>
+                <artifactId>scala-io-core_${scala.version}</artifactId>
+                <version>0.4.9</version>
+            </dependency>
+            <dependency>
+                <groupId>com.michaelpollmeier</groupId>
+                <artifactId>scala-arm_${scala.version}</artifactId>
+                <version>2.1</version>
             </dependency>
             <dependency>
                 <groupId>org.specs2</groupId>

--- a/csv-validator-ui/pom.xml
+++ b/csv-validator-ui/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-swing_${scala.version}</artifactId>
-            <version>2.1.1</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.designgridlayout</groupId>

--- a/csv-validator-ui/pom.xml
+++ b/csv-validator-ui/pom.xml
@@ -114,12 +114,12 @@
             <version>2.1.1</version>
         </dependency>
         <dependency>
-            <groupId>com.madgag</groupId>
+            <groupId>com.michaelpollmeier</groupId>
             <artifactId>scala-arm_${scala.compat.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.scala-incubator.io</groupId>
-            <artifactId>scala-io-file_${scala.compat.version}</artifactId>
+            <groupId>com.madgag</groupId>
+            <artifactId>scala-io-file_${scala.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <!-- see https://github.com/jesseeichar/scala-io/issues/94 -->

--- a/csv-validator-ui/pom.xml
+++ b/csv-validator-ui/pom.xml
@@ -110,23 +110,8 @@
         </dependency>
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-swing_${scala.compat.version}</artifactId>
+            <artifactId>scala-swing_${scala.version}</artifactId>
             <version>2.1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.michaelpollmeier</groupId>
-            <artifactId>scala-arm_${scala.compat.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.madgag</groupId>
-            <artifactId>scala-io-file_${scala.version}</artifactId>
-            <exclusions>
-                <exclusion>
-                    <!-- see https://github.com/jesseeichar/scala-io/issues/94 -->
-                    <groupId>org.scala-lang.modules</groupId>
-                    <artifactId>scala-parser-combinators_2.11</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.java.dev.designgridlayout</groupId>

--- a/csv-validator-ui/src/main/scala/scala/swing/PopupMenu.scala
+++ b/csv-validator-ui/src/main/scala/scala/swing/PopupMenu.scala
@@ -25,8 +25,8 @@ class PopupMenu(title0: String) extends SequentialContainer.Wrapper { self: Popu
  * scala.swing classes
  */
 object PopupMenuImplicits {
-  implicit def componentPopupMenu(component: Component): { def popupMenu(menu: PopupMenu) } = new {
-    def popupMenu(menu: PopupMenu) {
+  implicit def componentPopupMenu(component: Component): { def popupMenu(menu: PopupMenu) : Unit } = new {
+    def popupMenu(menu: PopupMenu) : Unit = {
       component.peer.setComponentPopupMenu(menu.peer)
     }
   }

--- a/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
+++ b/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
@@ -152,7 +152,7 @@ object CsvValidatorUi extends SimpleSwingApplication {
   private def saveToFile(s: String, f: Path) : Option[IOException] = {
     val data : Array[Byte] =  s.getBytes(UTF_8)
     try {
-      Files.write(f.toPath, data, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW)
+      Files.write(f, data, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW)
       None
     } catch {
       case ioe: IOException => Some(ioe)

--- a/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
+++ b/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
@@ -35,6 +35,8 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Files, Path, Paths, StandardOpenOption}
 import scala.util.Using
 
+import scala.language.reflectiveCalls
+
 /**
  * Simple GUI for the CSV Validator
  *
@@ -42,7 +44,7 @@ import scala.util.Using
  */
 object CsvValidatorUi extends SimpleSwingApplication {
 
-  override def startup(args: Array[String]) {
+  override def startup(args: Array[String]) : Unit = {
     try {
       UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName)
     } catch {
@@ -107,7 +109,7 @@ object CsvValidatorUi extends SimpleSwingApplication {
     }
   }
 
-  private def displayWait(suspendUi: => Unit, action: (String => Unit) => Unit, output: String => Unit, resumeUi: => Unit) {
+  private def displayWait(suspendUi: => Unit, action: (String => Unit) => Unit, output: String => Unit, resumeUi: => Unit) : Unit = {
     import scala.concurrent.Future
     import scala.concurrent.ExecutionContext.Implicits.global
     import scala.util.{Success, Failure}
@@ -128,7 +130,7 @@ object CsvValidatorUi extends SimpleSwingApplication {
     }
   }
 
-  private def validate(csvFilePath: String, csvEncoding: Charset, csvSchemaFilePath: String, csvSchemaEncoding: Charset, failOnFirstError: Boolean, pathSubstitutions: List[(String, String)], enforceCaseSensitivePathChecks: Boolean, progress: Option[ProgressCallback], validateEncoding: Boolean)(output: String => Unit) {
+  private def validate(csvFilePath: String, csvEncoding: Charset, csvSchemaFilePath: String, csvSchemaEncoding: Charset, failOnFirstError: Boolean, pathSubstitutions: List[(String, String)], enforceCaseSensitivePathChecks: Boolean, progress: Option[ProgressCallback], validateEncoding: Boolean)(output: String => Unit) : Unit = {
     output("")
     output(CsvValidatorCmdApp.validate(
       TextFile(Paths.get(csvFilePath), csvEncoding, validateEncoding),
@@ -175,7 +177,7 @@ object CsvValidatorUi extends SimpleSwingApplication {
     }
   }
 
-  private def saveSettings(settings: Settings) {
+  private def saveSettings(settings: Settings) : Unit = {
     if(!Files.exists(settingsFile)) {
       Files.createDirectories(settingsFile.getParent)
     }
@@ -256,14 +258,14 @@ object CsvValidatorUi extends SimpleSwingApplication {
     progressBar.labelPainted = true
     progressBar.label = ""
     private val progress = new ProgressCallback {
-      override def update(complete: this.type#Percentage) {
+      override def update(complete: this.type#Percentage) : Unit = {
         Swing.onEDT {
           progressBar.label = null
           progressBar.value = complete.toInt
         }
       }
 
-      override def update(total: Int, processed: Int) {
+      override def update(total: Int, processed: Int) : Unit = {
         Swing.onEDT {
           progressBar.max = total.toInt
           progressBar.value = processed
@@ -272,7 +274,7 @@ object CsvValidatorUi extends SimpleSwingApplication {
       }
     }
 
-    def outputToReport(data: String) {
+    def outputToReport(data: String) : Unit = {
       Swing.onEDT {
         txtArReport.text = data
       }
@@ -298,7 +300,7 @@ object CsvValidatorUi extends SimpleSwingApplication {
     private val separator2 = new Separator
 
     private val btnClose = new Button("Close")
-    btnClose.reactions += onClick(quit)
+    btnClose.reactions += onClick(quit())
 
     private val reportFileChooser = new FileChooser(loadSettings match {
       case Some(s) =>
@@ -344,7 +346,7 @@ object CsvValidatorUi extends SimpleSwingApplication {
     layout.row.grid(lblVersion)
   }
 
-  def updateLastPath(fileChooser: FileChooser, sink: Path => Settings) {
+  def updateLastPath(fileChooser: FileChooser, sink: Path => Settings) : Unit = {
     Option(fileChooser.selectedFile) match {
       case Some(selection) =>
         saveSettings(sink(selection.toPath.getParent))
@@ -387,11 +389,11 @@ object CsvValidatorUi extends SimpleSwingApplication {
       preferredViewportSize = new Dimension(500, 70)
       model = new DefaultTableModel(Array[Object]("From", "To"), 0)
 
-      def addRow(rowData: Array[String]) {
+      def addRow(rowData: Array[String]) : Unit = {
         model.asInstanceOf[DefaultTableModel].addRow(rowData.asInstanceOf[Array[AnyRef]])
       }
 
-      def removeSelectedRow() {
+      def removeSelectedRow() : Unit = {
         model.asInstanceOf[DefaultTableModel].removeRow(peer.getSelectedRow)
       }
 
@@ -402,7 +404,7 @@ object CsvValidatorUi extends SimpleSwingApplication {
 
     private val popupMenu = new PopupMenu
     private val miRemove = new MenuItem("Remove Path Substitution")
-    miRemove.reactions += onClick(tblPathSubstitutions.removeSelectedRow)
+    miRemove.reactions += onClick(tblPathSubstitutions.removeSelectedRow())
     popupMenu.contents += miRemove
     tblPathSubstitutions.popupMenu(popupMenu)
 

--- a/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
+++ b/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
@@ -10,10 +10,11 @@ package uk.gov.nationalarchives.csv.validator.ui
 
 import scala.swing._
 import resource._
+
 import javax.swing._
 import net.java.dev.designgridlayout._
-import java.io.{File, FileInputStream, FileOutputStream, PrintWriter}
 
+import java.io.{File, FileInputStream, FileOutputStream, IOException}
 import table.DefaultTableModel
 import uk.gov.nationalarchives.csv.validator.cmd.CsvValidatorCmdApp
 
@@ -22,24 +23,19 @@ import uk.gov.nationalarchives.csv.validator.ui.DesignGridImplicits._
 
 import scala.swing.PopupMenuImplicits._
 import ScalaSwingHelpers._
-import java.awt.{Cursor, Font}
-import java.util.Properties
 
+import java.awt.Cursor
+import java.util.Properties
 import scalax.file.Path
 import uk.gov.nationalarchives.csv.validator.ProgressCallback
-import java.nio.charset.Charset
 
+import java.nio.charset.Charset
 import uk.gov.nationalarchives.csv.validator.api.TextFile
+
 import java.util.jar.{Attributes, Manifest}
 import java.net.URL
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Files, StandardOpenOption}
-
-import scala.swing.Dialog.Message
-import scala.swing.event.ButtonClicked
-import javax.swing
-
-import scala.swing
 
 /**
  * Simple GUI for the CSV Validator
@@ -153,9 +149,14 @@ object CsvValidatorUi extends SimpleSwingApplication {
    * @param s
    * @param f
    */
-  private def saveToFile(s: String, f: File) {
+  private def saveToFile(s: String, f: File) : Option[IOException] = {
     val data : Array[Byte] =  s.getBytes(UTF_8)
-    Files.write(f.toPath, data, StandardOpenOption.WRITE)
+    try {
+      Files.write(f.toPath, data, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW)
+      None
+    } catch {
+      case ioe: IOException => Some(ioe)
+    }
   }
 
   case class Settings(lastCsvPath: File, lastCsvSchemaPath: File, lastReportPath: File)

--- a/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/SJXHelpers.scala
+++ b/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/SJXHelpers.scala
@@ -18,7 +18,7 @@ import uk.gov.nationalarchives.csv.validator.ui.SJXTaskPane.ViewStateChanged
  * scala.swing compatible implementation of JXFrame
  */
 class SJXFrame(gc: java.awt.GraphicsConfiguration = null) extends Frame(gc) {
-  override lazy val peer: JFrame with InterfaceMixin = new JXFrame(gc) with InterfaceMixin with SuperMixin
+  override lazy val peer: JFrame with InterfaceMixin2 = new JXFrame(gc) with InterfaceMixin2 with SuperMixin
 }
 
 /**
@@ -45,7 +45,7 @@ class SJXTaskPane(title: String) extends Panel with Publisher {
   }
   def add(component: Component) = peer.add(component.peer)
   def collapsed = peer.isCollapsed
-  def collapsed_= (c : Boolean) {
+  def collapsed_= (c : Boolean) : Unit = {
     peer.setCollapsed(c)
   }
 }

--- a/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/ScalaSwingHelpers.scala
+++ b/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/ScalaSwingHelpers.scala
@@ -29,7 +29,7 @@ object ScalaSwingHelpers {
    * @param output A text component which displays the absolute path of the chosen file
    * @param locateOver A component over which the FileChooser dialog should be located
    */
-  def chooseFile(fileChooser: FileChooser, output: TextComponent, locateOver: Component) {
+  def chooseFile(fileChooser: FileChooser, output: TextComponent, locateOver: Component) : Unit = {
     chooseFile(fileChooser, {f => output.text = f.toAbsolutePath.toString; None}, locateOver)
   }
 
@@ -40,7 +40,7 @@ object ScalaSwingHelpers {
    * @param result A function which takes the chosen file
    * @param locateOver A component over which the FileChooser dialog should be located
    */
-  def chooseFile(fileChooser: FileChooser, result: Path => Option[IOException], locateOver: Component) {
+  def chooseFile(fileChooser: FileChooser, result: Path => Option[IOException], locateOver: Component) : Unit = {
     fileChooser.showSaveDialog(locateOver) match {
       case Result.Approve =>
         result(fileChooser.selectedFile.toPath) match {
@@ -62,7 +62,7 @@ object ScalaSwingHelpers {
    * @param table The table to create a dialog for
    * @param result A function which takes a row as the result of the dialog box
    */
-  def addToTableDialog(owner: Window, title: String, table: Table, result: Array[String] => Unit) {
+  def addToTableDialog(owner: Window, title: String, table: Table, result: Array[String] => Unit) : Unit = {
 
     val btnOk = new Button("Ok")
 
@@ -100,7 +100,7 @@ object ScalaSwingHelpers {
       } yield component.asInstanceOf[TextField].text
       textValues.toArray}
     ))
-    btnOk.reactions += onClick(dialog.close)
+    btnOk.reactions += onClick(dialog.close())
 
     dialog.visible = true
   }
@@ -130,6 +130,8 @@ object ScalaSwingHelpers {
   }
 
   def PropertyChangeListener(f: PropertyChangeEvent => Unit) = new PropertyChangeListener {
-    def propertyChange(e: PropertyChangeEvent) { f(e) }
+    def propertyChange(e: PropertyChangeEvent) : Unit = {
+      f(e)
+    }
   }
 }

--- a/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/ScalaSwingHelpers.scala
+++ b/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/ScalaSwingHelpers.scala
@@ -15,6 +15,7 @@ import swing.GridBagPanel.Anchor
 import java.beans.{PropertyChangeEvent, PropertyChangeListener}
 import java.nio.file.Path
 import scala.swing.Dialog.Message
+import java.io.IOException
 
 /**
  * Some simple helpers to ease

--- a/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/ScalaSwingHelpers.scala
+++ b/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/ScalaSwingHelpers.scala
@@ -10,10 +10,10 @@ package uk.gov.nationalarchives.csv.validator.ui
 
 import swing._
 import scala.swing.event.{ButtonClicked, Key, KeyPressed, MouseClicked}
-import java.io.{File, IOException}
 import swing.FileChooser.Result
 import swing.GridBagPanel.Anchor
 import java.beans.{PropertyChangeEvent, PropertyChangeListener}
+import java.nio.file.Path
 import scala.swing.Dialog.Message
 
 /**
@@ -30,7 +30,7 @@ object ScalaSwingHelpers {
    * @param locateOver A component over which the FileChooser dialog should be located
    */
   def chooseFile(fileChooser: FileChooser, output: TextComponent, locateOver: Component) {
-    chooseFile(fileChooser, {f => output.text = f.getAbsolutePath; None}, locateOver)
+    chooseFile(fileChooser, {f => output.text = f.toAbsolutePath.toString; None}, locateOver)
   }
 
   /**
@@ -40,10 +40,10 @@ object ScalaSwingHelpers {
    * @param result A function which takes the chosen file
    * @param locateOver A component over which the FileChooser dialog should be located
    */
-  def chooseFile(fileChooser: FileChooser, result: File => Option[IOException], locateOver: Component) {
+  def chooseFile(fileChooser: FileChooser, result: Path => Option[IOException], locateOver: Component) {
     fileChooser.showSaveDialog(locateOver) match {
       case Result.Approve =>
-        result(fileChooser.selectedFile) match {
+        result(fileChooser.selectedFile.toPath) match {
           case Some(ioe) =>
             ioe.printStackTrace()
             Dialog.showMessage(fileChooser, s"${ioe.getClass.getName}: ${ioe.getMessage}", "Unable to Save file", Message.Error)

--- a/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/ScalaSwingHelpers.scala
+++ b/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/ScalaSwingHelpers.scala
@@ -9,12 +9,12 @@
 package uk.gov.nationalarchives.csv.validator.ui
 
 import swing._
-import scala.swing.event.{MouseClicked, KeyPressed, Key, ButtonClicked}
-import java.io.File
+import scala.swing.event.{ButtonClicked, Key, KeyPressed, MouseClicked}
+import java.io.{File, IOException}
 import swing.FileChooser.Result
 import swing.GridBagPanel.Anchor
-import java.awt.event.{MouseEvent, MouseListener, ActionListener, ActionEvent}
 import java.beans.{PropertyChangeEvent, PropertyChangeListener}
+import scala.swing.Dialog.Message
 
 /**
  * Some simple helpers to ease
@@ -30,7 +30,7 @@ object ScalaSwingHelpers {
    * @param locateOver A component over which the FileChooser dialog should be located
    */
   def chooseFile(fileChooser: FileChooser, output: TextComponent, locateOver: Component) {
-    chooseFile(fileChooser, f => output.text = f.getAbsolutePath, locateOver)
+    chooseFile(fileChooser, {f => output.text = f.getAbsolutePath; None}, locateOver)
   }
 
   /**
@@ -40,10 +40,15 @@ object ScalaSwingHelpers {
    * @param result A function which takes the chosen file
    * @param locateOver A component over which the FileChooser dialog should be located
    */
-  def chooseFile(fileChooser: FileChooser, result: File => Unit, locateOver: Component) {
-    fileChooser.showOpenDialog(locateOver) match {
+  def chooseFile(fileChooser: FileChooser, result: File => Option[IOException], locateOver: Component) {
+    fileChooser.showSaveDialog(locateOver) match {
       case Result.Approve =>
-        result(fileChooser.selectedFile)
+        result(fileChooser.selectedFile) match {
+          case Some(ioe) =>
+            ioe.printStackTrace()
+            Dialog.showMessage(fileChooser, s"${ioe.getClass.getName}: ${ioe.getMessage}", "Unable to Save file", Message.Error)
+          case None =>
+        }
       case Result.Cancel =>
     }
   }


### PR DESCRIPTION
This should put us in a good place to support Java 9 (shortly when Scala supports it) and also to further improve the performance of both the CSV Parser and the CSV Schema Parser.

We could also now create a better GUI for the UI using ScalaFX (JavaFX requires Java 8).