### PR TITLE
Switch to UniVocity CSV Parser for better performance

### DIFF
--- a/csv-validator-core/pom.xml
+++ b/csv-validator-core/pom.xml
@@ -135,9 +135,9 @@
             <version>1.6.2</version>
         </dependency>
         <dependency>
-            <groupId>com.opencsv</groupId>
-            <artifactId>opencsv</artifactId>
-            <version>3.3</version>
+            <groupId>com.univocity</groupId>
+            <artifactId>univocity-parsers</artifactId>
+            <version>2.5.7</version>
         </dependency>
         <dependency>
             <groupId>com.gilt</groupId>

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidator.scala
@@ -13,18 +13,21 @@ import uk.gov.nationalarchives.utf8.validator.{Utf8Validator, ValidationHandler}
 
 import scala.language.{postfixOps, reflectiveCalls}
 import scala.util.Try
-import scalaz._, Scalaz._
-import java.io.{IOException, Reader => JReader, InputStreamReader => JInputStreamReader, FileInputStream => JFileInputStream, LineNumberReader => JLineNumberReader}
-import java.nio.charset.StandardCharsets;
+import scalaz._
+import Scalaz._
+import java.io.{IOException, FileInputStream => JFileInputStream, InputStreamReader => JInputStreamReader, LineNumberReader => JLineNumberReader, Reader => JReader}
+import java.nio.charset.StandardCharsets
+
 import resource._
 import uk.gov.nationalarchives.csv.validator.schema._
 import uk.gov.nationalarchives.csv.validator.metadata.Cell
-import scalax.file.Path
 
-import org.apache.commons.io.input.BOMInputStream;
-import org.apache.commons.io.ByteOrderMark;
-import com.opencsv.{CSVParser, CSVReader}
+import scalax.file.Path
+import org.apache.commons.io.input.BOMInputStream
+import com.univocity.parsers.common.TextParsingException
+import com.univocity.parsers.csv.{CsvParser, CsvParserSettings}
 import uk.gov.nationalarchives.csv.validator.metadata.Row
+
 import scala.annotation.tailrec
 import uk.gov.nationalarchives.csv.validator.api.TextFile
 
@@ -82,20 +85,36 @@ trait MetaDataValidator {
 
   def validateKnownRows(csv: JReader, schema: Schema, progress: Option[ProgressFor]): MetaDataValidation[Any] = {
 
-    val separator = schema.globalDirectives.collectFirst {
+    val separator: Char = schema.globalDirectives.collectFirst {
       case Separator(sep) =>
         sep
-    }.getOrElse(CSVParser.DEFAULT_SEPARATOR)
+    }.getOrElse(CSV_RFC1480_SEPARATOR)
 
-    val quote = schema.globalDirectives.collectFirst {
+    val quote: Option[Char] = schema.globalDirectives.collectFirst {
       case q: Quoted =>
-        CSVParser.DEFAULT_QUOTE_CHARACTER
+        CSV_RFC1480_QUOTE_CHARACTER
     }
 
-    //TODO CSVReader does not appear to be RFC 4180 compliant as it does not support escaping a double-quote with a double-quote between double-quotes
-    //TODO CSVReader does not seem to allow you to enable/disable quoted columns
+    val settings = new CsvParserSettings()
+    val format = settings.getFormat
+    format.setDelimiter(separator)
+    quote.map(format.setQuote)
+
+    /* Set RFC 1480 settings */
+    settings.setIgnoreLeadingWhitespaces(false)
+    settings.setIgnoreTrailingWhitespaces(false)
+    settings.setLineSeparatorDetectionEnabled(true)
+    // TODO(AR) should we be friendly and auto-detect line separator, or enforce RFC 1480?
+    format.setQuoteEscape(CSV_RFC1480_QUOTE_ESCAPE_CHARACTER)
+    //format.setLineSeparator(CSV_RFC1480_LINE_SEPARATOR)  // CRLF
+
     //we need a better CSV Reader!
-    managed(new CSVReader(csv, separator, CSVParser.DEFAULT_QUOTE_CHARACTER, CSVParser.NULL_CHARACTER)) map {
+    makeManagedResource {
+      val parser = new CsvParser(settings)
+      parser.beginParsing(csv)
+      parser
+    } (_.stopParsing()) (List(classOf[IOException], classOf[TextParsingException], classOf[IllegalStateException]))
+      .map {
       reader =>
 
         // if 'no header' is set but the file is empty and 'permit empty' has not been set - this is an error
@@ -157,7 +176,7 @@ trait MetaDataValidator {
       acc :+ filename(row, columnIndex)
     }
 
-  def filename(row: Row,titleIndex: Int): String = row.cells.map(_.value).apply(titleIndex)
+  def filename(row: Row,titleIndex: Int): String = row.cells(titleIndex).value
 
 
   def validateRows(rows: Iterator[Row], schema: Schema): MetaDataValidation[Any]
@@ -290,10 +309,10 @@ trait ProgressCallback {
   def update(total: Int, processed: Int): Unit = update((processed.toFloat / total.toFloat) * 100)
 }
 
-class RowIterator(reader: CSVReader, progress: Option[ProgressFor]) extends Iterator[Row] {
+class RowIterator(parser: CsvParser, progress: Option[ProgressFor]) extends Iterator[Row] {
 
   private var index = 1
-  private var current = toRow(Option(reader.readNext()))
+  private var current = toRow(Option(parser.parseNext()))
 
   @throws(classOf[IOException])
   override def next(): Row = {
@@ -307,7 +326,7 @@ class RowIterator(reader: CSVReader, progress: Option[ProgressFor]) extends Iter
 
     //move to the next
     this.index = index + 1
-    this.current = toRow(Option(reader.readNext()))
+    this.current = toRow(Option(parser.parseNext()))
 
     progress map {
       p =>
@@ -327,5 +346,5 @@ class RowIterator(reader: CSVReader, progress: Option[ProgressFor]) extends Iter
 
   override def hasNext: Boolean = current.nonEmpty
 
-  private def toRow(rowData: Option[Array[String]]): Option[Row] = rowData.map(data => Row(data.toList.map(Cell(_)), index))
+  private def toRow(rowData: Option[Array[String]]): Option[Row] = rowData.map(data => Row(data.toList.map(d => Cell(Option(d).getOrElse(""))), index))
 }

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/package.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/package.scala
@@ -31,4 +31,14 @@ package object validator {
   val UNIX_FILE_SEPARATOR = '/'
 
   val URI_PATH_SEPARATOR = '/'
+
+  val CSV_RFC1480_SEPARATOR: Char = ','
+
+  val CSV_RFC1480_QUOTE_CHARACTER: Char = '"'
+
+  val CSV_RFC1480_QUOTE_ESCAPE_CHARACTER: Char = '"'
+
+  val CSV_RFC1480_LINE_SEPARATOR = Array('\r', '\n')
+
+
 }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
@@ -533,7 +533,8 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
 
   "Concat string provider" should {
     "should concatenate string provider" in {
-      validate(TextFile(Path.fromString(base) / "concatPass.csv"), parse(base + "/concat.csvs"), None).isSuccess mustEqual true
+      val x = validate(TextFile(Path.fromString(base) / "concatPass.csv"), parse(base + "/concat.csvs"), None)
+      x.isSuccess mustEqual true
     }
 
     "fail for incorrect concatenation" in {


### PR DESCRIPTION
This switches out the venerable OpenCSV parser, for the more modern and highly performant UniVocity CSV parser.

Using the 144MB [worldcitiespop.txt](http://www.maxmind.com/download/worldcities/worldcitiespop.txt.gz) and the following CSV Schema:

```csvschema
version 1.2
@totalColumns 7
Country:
City:
AccentCity:
Region:
Population:
Latitude:
Longitude:
```

Results when now using the UniVocity parser:

```bash
$ wget http://www.maxmind.com/download/worldcities/worldcitiespop.txt.gz
$ gunzip worldcitiespop.txt.gz
$ iconv -f ISO-8859-1 -t UTF-8 worldcitiespop.txt > worldcitiespop-utf8.csv
$ cat worldcitiespop-utf8.csv | sed 's/"//g' | sed "s/'//g" > worldcitiespop-utf8-2.csv

$ time csv-validator-cmd/target/appassembler/bin/validate --fail-fast true worldcitiespop-utf8-2.csv worldcitiespop.csvs 

PASS

real	0m20.420s
user	0m22.517s
sys	0m0.660s
```

Results with the previous OpenCSV parser:
```bash
PASS

real	0m25.505s
user	0m27.199s
sys	0m0.855s
```

From this we see that the UniVocity parser is ~20% faster than the OpenCSV parser. The gain is even more pronounced on smaller files.

Also the UniVocity provider gives us much more control over the parsing format for the CSV file :-)