### PR TITLE
Updated MetaDataValidator.scala.

### DIFF
--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidator.scala
@@ -95,7 +95,7 @@ trait MetaDataValidator {
     //TODO CSVReader does not appear to be RFC 4180 compliant as it does not support escaping a double-quote with a double-quote between double-quotes
     //TODO CSVReader does not seem to allow you to enable/disable quoted columns
     //we need a better CSV Reader!
-    managed(new CSVReader(csv, separator, CSVParser.DEFAULT_QUOTE_CHARACTER, CSVParser.NULL_CHARACTER)) map {
+    managed(new CSVReader(csv, separator, CSVParser.DEFAULT_QUOTE_CHARACTER, CSVParser.DEFAULT_ESCAPE_CHARACTER)) map {
       reader =>
 
         // if 'no header' is set but the file is empty and 'permit empty' has not been set - this is an error


### PR DESCRIPTION
The fourth argument to the constructor of CSVReader is "escape charactor".

In this modification, you will be double quotes of escape can be correctly.

reference:
http://opencsv.sourceforge.net/apidocs/com/opencsv/CSVReader.html#CSVReader(java.io.Reader, char, char, char)