### PR TITLE
Address version conflict with competing Parser Combinators libraries

### DIFF
--- a/csv-validator-cmd/pom.xml
+++ b/csv-validator-cmd/pom.xml
@@ -133,6 +133,12 @@
         <dependency>
             <groupId>com.github.scala-incubator.io</groupId>
             <artifactId>scala-io-file_${scala.compat.version}</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.scala-lang.modules</groupId>
+                    <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/csv-validator-core/pom.xml
+++ b/csv-validator-core/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.scalaz</groupId>

--- a/csv-validator-java-api/pom.xml
+++ b/csv-validator-java-api/pom.xml
@@ -128,6 +128,12 @@
         <dependency>
             <groupId>com.github.scala-incubator.io</groupId>
             <artifactId>scala-io-file_${scala.compat.version}</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.scala-lang.modules</groupId>
+                    <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Only use the newest Scala Parser Combinators available for Scala 2.11

Closes https://github.com/digital-preservation/csv-validator/issues/330
Closes https://github.com/digital-preservation/csv-validator/issues/324
Closes https://github.com/digital-preservation/csv-validator/issues/319