### PR TITLE
Bug 130 out of memory too many errors

### DIFF
--- a/csv-validator-cmd/src/main/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdApp.scala
+++ b/csv-validator-cmd/src/main/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdApp.scala
@@ -9,18 +9,18 @@
 package uk.gov.nationalarchives.csv.validator.cmd
 
 
-import java.text.DecimalFormat
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import scopt.Read
 import uk.gov.nationalarchives.csv.validator._
-import uk.gov.nationalarchives.csv.validator.api.{CsvValidator, TextFile}
 import uk.gov.nationalarchives.csv.validator.api.CsvValidator.{SubstitutePath, createValidator}
+import uk.gov.nationalarchives.csv.validator.api.{CsvValidator, TextFile}
 
 import java.net.URL
 import java.nio.charset.Charset
 import java.nio.file.{Files, Path, Paths}
+import java.text.DecimalFormat
 import java.util.jar.{Attributes, Manifest}
 import scala.util.Using
-import cats.data.{NonEmptyList, Validated, ValidatedNel}
 
 object SystemExitCodes extends Enumeration {
   type ExitCode = Int

--- a/csv-validator-cmd/src/main/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdApp.scala
+++ b/csv-validator-cmd/src/main/scala/uk/gov/nationalarchives/csv/validator/cmd/CsvValidatorCmdApp.scala
@@ -160,7 +160,7 @@ object CsvValidatorCmdApp extends App {
           progress,
           onRow
         )
-        if (pass) ("PASS", SystemExitCodes.ValidCsv) else ("", SystemExitCodes.InvalidCsv)
+        if (pass) ("PASS", SystemExitCodes.ValidCsv) else ("FAIL", SystemExitCodes.InvalidCsv)
     }
   }
 

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/AllErrorsMetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/AllErrorsMetaDataValidator.scala
@@ -8,21 +8,18 @@
  */
 package uk.gov.nationalarchives.csv.validator
 
-import uk.gov.nationalarchives.csv.validator.schema.Optional
-import uk.gov.nationalarchives.csv.validator.schema.Rule
-import uk.gov.nationalarchives.csv.validator.schema.Schema
-import uk.gov.nationalarchives.csv.validator.schema.Warning
-import uk.gov.nationalarchives.csv.validator.metadata.Cell
-import uk.gov.nationalarchives.csv.validator.metadata.Row
-import scala.annotation.tailrec
 import cats.syntax.all._
+import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
+import uk.gov.nationalarchives.csv.validator.schema.{Optional, Rule, Schema, Warning}
+
+import scala.annotation.tailrec
 
 trait AllErrorsMetaDataValidator extends MetaDataValidator {
 
   override def validateRows(
     rows: Iterator[Row],
     schema: Schema,
-    rowCallback: MetaDataValidation[Any] => Unit = {_ => ()}    
+    rowCallback: MetaDataValidation[Any] => Unit
   ): Boolean = {
 
     @tailrec

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/FailFastMetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/FailFastMetaDataValidator.scala
@@ -8,16 +8,12 @@
  */
 package uk.gov.nationalarchives.csv.validator
 
-import annotation.tailrec
-import uk.gov.nationalarchives.csv.validator.schema.ColumnDefinition
-import uk.gov.nationalarchives.csv.validator.schema.Optional
-import uk.gov.nationalarchives.csv.validator.schema.Rule
-import uk.gov.nationalarchives.csv.validator.schema.Schema
-import uk.gov.nationalarchives.csv.validator.schema.Warning
-import uk.gov.nationalarchives.csv.validator.metadata.Cell
-import uk.gov.nationalarchives.csv.validator.metadata.Row
 import cats.data.Validated.{Invalid => Failure}
 import cats.syntax.all._
+import uk.gov.nationalarchives.csv.validator.metadata.{Cell, Row}
+import uk.gov.nationalarchives.csv.validator.schema._
+
+import scala.annotation.tailrec
 
 trait FailFastMetaDataValidator extends MetaDataValidator {
 
@@ -26,7 +22,7 @@ trait FailFastMetaDataValidator extends MetaDataValidator {
   override def validateRows(
     rows: Iterator[Row],
     schema: Schema,
-    rowCallback: MetaDataValidation[Any] => Unit = {_ => ()}    
+    rowCallback: MetaDataValidation[Any] => Unit
   ): Boolean = {
 
     @tailrec

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/FailFastMetaDataValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/FailFastMetaDataValidator.scala
@@ -24,29 +24,28 @@ trait FailFastMetaDataValidator extends MetaDataValidator {
 
   //TODO(AR) work on removing use of `Any`
 
-  override def validateRows(rows: Iterator[Row], schema: Schema): MetaDataValidation[Any] = {
+  override def validateRows(
+    rows: Iterator[Row],
+    schema: Schema,
+    rowCallback: MetaDataValidation[Any] => Unit = {_ => ()}    
+  ): Boolean = {
 
     @tailrec
-    def validateRows(results: List[MetaDataValidation[Any]] = List.empty[MetaDataValidation[Any]]) : List[MetaDataValidation[Any]] = {
-      if(results.headOption.map(containsErrors(_)).getOrElse(false) || !rows.hasNext) {
-        results.reverse
+    def inner(passing: Boolean) : Boolean = {
+      if(!rows.hasNext) {
+        passing
       } else {
         val row = rows.next()
         val result = validateRow(row, schema, Some(rows.hasNext))
-        /*
-        Only store the results if they contain a warning or a failure.  This means the validator is not limited by the
-        available memory when processing large files.
-        */
-        if (containsErrors(result) || containsWarnings(result)) {
-          validateRows(result :: results)
-         } else {
-            validateRows(results)
-        }
+        rowCallback(result)
+        if(!containsErrors(result))
+          inner(passing)
+        else 
+          false
       }
     }
 
-    val v = validateRows()
-    v.sequence[MetaDataValidation, Any]
+    inner(true)
   }
 
   override protected def rules(row: Row,  schema: Schema, mayBeLast: Option[Boolean] = None): MetaDataValidation[List[Any]] = {

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidator.scala
@@ -8,14 +8,14 @@
  */
 package uk.gov.nationalarchives.csv.validator.api
 
-import uk.gov.nationalarchives.csv.validator.schema.{Schema, SchemaParser}
+import cats.data.{Chain, Validated, ValidatedNel}
+import cats.implicits._
 import uk.gov.nationalarchives.csv.validator._
+import uk.gov.nationalarchives.csv.validator.schema.{Schema, SchemaParser}
 
 import java.io.{Reader => JReader}
 import java.nio.charset.{Charset => JCharset}
 import java.nio.file.Path
-import cats.data.{Chain, NonEmptyChain, Validated, ValidatedNel}
-import cats.implicits._
 
 object CsvValidator {
 

--- a/csv-validator-ui/pom.xml
+++ b/csv-validator-ui/pom.xml
@@ -132,6 +132,12 @@
             <artifactId>swingx-core</artifactId>
             <version>1.6.5-1</version>
         </dependency>
+        <dependency>
+            <groupId>org.typelevel</groupId>
+            <artifactId>cats-core_${scala.version}</artifactId>
+            <version>${cats.core.version}</version>
+        </dependency>
+
 
         <!-- TODO needed by CsvValidatorUi.scala but ideally should depend on just csv-validator-core and NOT csv-validator-cmd -->
         <dependency>

--- a/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
+++ b/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
@@ -8,35 +8,30 @@
  */
 package uk.gov.nationalarchives.csv.validator.ui
 
-import scala.swing._
-import javax.swing._
-import net.java.dev.designgridlayout._
-
-import java.io.{File, FileInputStream, FileOutputStream, IOException}
-import table.DefaultTableModel
-import uk.gov.nationalarchives.csv.validator.cmd.{CsvValidatorCmdApp, SystemExitCodes}
-
-import swing.GridBagPanel.Anchor
-import uk.gov.nationalarchives.csv.validator.ui.DesignGridImplicits._
-
-import scala.swing.PopupMenuImplicits._
-import ScalaSwingHelpers._
 import cats.data.Validated.Invalid
 import cats.data.ValidatedNel
+import net.java.dev.designgridlayout._
+import uk.gov.nationalarchives.csv.validator.api.TextFile
+import uk.gov.nationalarchives.csv.validator.cmd.{CsvValidatorCmdApp, SystemExitCodes}
+import uk.gov.nationalarchives.csv.validator.ui.DesignGridImplicits._
+import uk.gov.nationalarchives.csv.validator.ui.ScalaSwingHelpers._
+import uk.gov.nationalarchives.csv.validator.{EOL, FailMessage, ProgressCallback}
 
 import java.awt.Cursor
-import java.util.Properties
-import uk.gov.nationalarchives.csv.validator.{FailMessage, ProgressCallback}
-
-import java.nio.charset.Charset
-import uk.gov.nationalarchives.csv.validator.api.TextFile
-
-import java.util.jar.{Attributes, Manifest}
+import java.io.IOException
 import java.net.URL
+import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Files, Path, Paths, StandardOpenOption}
-import scala.util.Using
+import java.util.Properties
+import java.util.jar.{Attributes, Manifest}
+import javax.swing._
+import javax.swing.table.DefaultTableModel
 import scala.language.reflectiveCalls
+import scala.swing.GridBagPanel.Anchor
+import scala.swing.PopupMenuImplicits._
+import scala.swing._
+import scala.util.Using
 
 /**
  * Simple GUI for the CSV Validator
@@ -111,9 +106,9 @@ object CsvValidatorUi extends SimpleSwingApplication {
   }
 
   private def displayWait(suspendUi: => Unit, action: (String => Unit) => Unit, output: String => Unit, resumeUi: => Unit) : Unit = {
-    import scala.concurrent.Future
     import scala.concurrent.ExecutionContext.Implicits.global
-    import scala.util.{Success, Failure}
+    import scala.concurrent.Future
+    import scala.util.{Failure, Success}
 
     suspendUi
     val fAction: Future[Unit] = Future {
@@ -308,7 +303,7 @@ object CsvValidatorUi extends SimpleSwingApplication {
 
     def outputToReport(data: String) : Unit = 
       Swing.onEDT {
-        txtArReport.append(data+"\n")
+        txtArReport.append(data + EOL)
       }
 
 

--- a/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
+++ b/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
@@ -21,10 +21,12 @@ import uk.gov.nationalarchives.csv.validator.ui.DesignGridImplicits._
 
 import scala.swing.PopupMenuImplicits._
 import ScalaSwingHelpers._
+import cats.data.Validated.Invalid
+import cats.data.ValidatedNel
 
 import java.awt.Cursor
 import java.util.Properties
-import uk.gov.nationalarchives.csv.validator.{ProgressCallback, FailMessage}
+import uk.gov.nationalarchives.csv.validator.{FailMessage, ProgressCallback}
 
 import java.nio.charset.Charset
 import uk.gov.nationalarchives.csv.validator.api.TextFile
@@ -34,7 +36,6 @@ import java.net.URL
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Files, Path, Paths, StandardOpenOption}
 import scala.util.Using
-import scalaz.{Failure => FailureZ, _}
 import scala.language.reflectiveCalls
 
 /**
@@ -139,9 +140,9 @@ object CsvValidatorUi extends SimpleSwingApplication {
     var badLines = 0
     var truncated = false
 
-    def rowCallback(row: ValidationNel[FailMessage, Any]): Unit = row match {
+    def rowCallback(row: ValidatedNel[FailMessage, Any]): Unit = row match {
 
-      case FailureZ(failures) =>
+      case Invalid(failures) =>
         if (badLines > 2000) {
           if (!truncated) {
             toConsole("Too many errors/warnings, truncating")

--- a/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
+++ b/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
@@ -23,10 +23,10 @@ import java.net.URL
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Files, Path, Paths, StandardOpenOption}
-import javax.swing.filechooser.FileNameExtensionFilter
 import java.util.Properties
 import java.util.jar.{Attributes, Manifest}
 import javax.swing._
+import javax.swing.filechooser.FileNameExtensionFilter
 import javax.swing.table.DefaultTableModel
 import scala.language.reflectiveCalls
 import scala.swing.GridBagPanel.Anchor
@@ -160,8 +160,14 @@ object CsvValidatorUi extends SimpleSwingApplication {
       pathSubstitutions,
       enforceCaseSensitivePathChecks,
       false,
-      progress
-    )._1)
+      progress,
+      rowCallback
+    )._2 match {
+      case SystemExitCodes.ValidCsv => toConsole("PASS")
+      case _ => toConsole("FAIL")
+    }
+
+
   }
 
   /**


### PR DESCRIPTION
The master branch will run out of heap in the event of too many errors or warnings being emitted.
This fault occurs because the existing logic accumulates the errors in memory until the end of execution. 

This modified version deprecates the validate methods that collect the errors and introduces new methods that instead allow use of a callback method, in the case of the cli application this emits them straight to stdout and in the case of the gui it places them in the textarea but maintains a cap of 2000 rows worth of errors or warnings to be displayed. 

Note that this is not a particularly elegant solution, it doesn't capture effects and it uses variables inside some of the methods that would be unsafe were we to use this multi-threaded. I believe the preferred solution longer-term would be to use fs2 to stream the rows as demonstrated in the fs2-end-to-end branch, but as that branch is a major restructure of the code I think this change makes sense to address the bug in the short-term. 