### PR TITLE
BUG#128: Better error messages for invalid column references in concat

### DIFF
--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaValidator.scala
@@ -15,6 +15,7 @@ import uk.gov.nationalarchives.csv.validator.schema._
 
 import scala.collection.immutable.TreeMap
 import scala.util.Try
+import uk.gov.nationalarchives.csv.validator.schema.v1_1.Concat
 
 /**
  * Set of rules to validate the schema (compatible with the CSV Schema 1.0)
@@ -132,8 +133,9 @@ class SchemaValidator {
  protected def crossColumnsValid(columnDefinitions: List[ColumnDefinition]): Option[String] = {
    def filterRules(cds: ColumnDefinition ): List[Rule] = { // List of failing rules
      cds.rules.filter(rule => {
-       def undefinedCross(a: ArgProvider) = a match {
+       def undefinedCross(a: ArgProvider): Boolean = a match {
          case ColumnReference(name) => !columnDefinitions.exists(col => col.id == name)
+         case concat: Concat => concat.args.exists(undefinedCross)
          case _ => false
        }
 


### PR DESCRIPTION
A schema with an invalid column reference inside concat doesn't give helpful error messages at present. With this change applied - 
```
version 1.1
@totalColumns 3
c1:
c2:
c3: is(concat($c2,$c4))
```
will now give an error message saying 'Column: c3 has invalid cross reference is(concat($c2, $c4)) at line: 5, column: 5'
rather than just 'Invalid column definition'. 
