### PR TITLE
bug 299: fix for malformed error message with switch rules

### DIFF
--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/Rule.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/Rule.scala
@@ -57,10 +57,9 @@ case class SwitchRule(elseRules: Option[List[Rule]], cases:(Rule, List[Rule])*) 
     }.sequence[RuleValidation, Any]
   }
 
-
   override def toError = {
-    val paramErrs = cases.flatMap{ case (_,rules) => rules.map( _.toError).mkString(" ")}
-    s"""($paramErrs)""" + (if (argProviders.isEmpty) "" else "(" + argProviders.foldLeft("")((a, b) => (if (a.isEmpty) "" else a + ", ") + b.toError) + ")")
+    val paramErrs = cases.map{ case (x,rules) => "(" + x.toError + ", " + rules.map( _.toError).mkString(" ") + ")" }.mkString(", ")
+    s"""${super.toError}($paramErrs)"""
   }
 }
 


### PR DESCRIPTION
https://github.com/digital-preservation/csv-validator/issues/299

Note that this doesn't resolve the issue with the error message for unique being truncated as also shown in this ticket as that is a duplicate of https://github.com/digital-preservation/csv-validator/issues/84.