### PR TITLE
Add a Docker Image build for the Command Line tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A [comprehensive user guide is available in GitHub pages](http://digital-preserv
 
 Technology
 ----------
-The Validation tool and APIs are written in Scala 2.11 and may be used as:
+The Validation tool and APIs are written in Scala 2.13 and may be used as:
 
 * A stand-alone command line tool.
 
@@ -20,10 +20,14 @@ The Validation tool and APIs are written in Scala 2.11 and may be used as:
 
 * A library in your Scala project.
 
-* A library in your Java project (We provide a Java 7 interface, to make things simple for Java programmers too).
+* A library in your Java project (We provide a Java 8 interface, to make things simple for Java programmers too).
 
-The Validation Tool and APIs can be used on any Java Virtual Machine which supports Java 7 or better (**NB Java 6 support was removed in version 1.1**). The source code is
-built using the [Apache Maven](https://maven.apache.org/) build tool, by executing `mvn clean install`.
+The Validation Tool and APIs can be used on any Java Virtual Machine which supports Java 8 or better (**NB Java 6 support was removed in version 1.1**). The source code is
+built using the [Apache Maven](https://maven.apache.org/) build tool:
+
+1. For use in other Java/Scala Applications, build by executing `mvn clean install`.
+2. For the Command Line Interface or Swing GUI, build by executing `mvn clean package`.
+3. For the Docker image (`nationalarchives/csv-validator:latest`), build by executing `mvn clean package -Pdocker`.
 
 
 Maven Artifacts
@@ -38,7 +42,7 @@ If you wish to use the CSV Validator from your own Java project, we provide a na
 <dependency>
 	<groupId>uk.gov.nationalarchives</groupId>
     <artifactId>csv-validator-java-api</artifactId>
-    <version>1.1</version>
+    <version>1.2-RC4</version>
 </dependency>
 ```
 
@@ -77,7 +81,7 @@ Likewise, if you wish to use the CSV Validator from your own Scala project, the 
 <dependency>
 	<groupId>uk.gov.nationalarchives</groupId>
     <artifactId>csv-validator-core</artifactId>
-    <version>1.1.5</version>
+    <version>1.2-RC4</version>
 </dependency>
 ```
 
@@ -87,6 +91,17 @@ An example of using the Scala API can be found in the class `uk.gov.nationalarch
 `csv-validator-java-api` module. The Scala API at present gives much more control over the individual Schema Parsing and Validation Processor
 than the Java API.
 
+Docker Container (of CSV Validator Command Line Tool)
+=====================================================
+To see the options run:
+```bash
+docker run nationalarchives/csv-validator
+```
+
+Then for example, to validate `/tmp/my-data.csv` with `/tmp/my-schema.csvs` you would run:
+```bash
+docker run nationalarchives/csv-validator /tmp/my-data.csv /tmp/my-schema.csvs
+```
 
 Schema Examples
 ===============

--- a/csv-validator-cmd/pom.xml
+++ b/csv-validator-cmd/pom.xml
@@ -18,8 +18,13 @@
         <connection>scm:git:https://github.com/digital-preservation/csv-validator.git</connection>
         <developerConnection>scm:git:https://github.com/digital-preservation/csv-validator.git</developerConnection>
         <url>scm:git:https://github.com/digital-preservation/csv-validator.git</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
+
+    <properties>
+        <assemble.dir>${project.build.directory}/${project.artifactId}-${project.version}-application/${project.artifactId}-${project.version}</assemble.dir>
+        <docker.tag>latest</docker.tag>
+    </properties>
 
     <build>
         <plugins>
@@ -93,6 +98,7 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
@@ -156,5 +162,70 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>docker</id>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>src/main/resources-filtered</directory>
+                        <filtering>true</filtering>
+                    </resource>
+                </resources>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>resources</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <version>0.40.3</version>
+                        <configuration>
+                            <verbose>true</verbose>
+                            <images>
+                                <image>
+                                    <name>nationalarchives/csv-validator:%v</name>
+                                    <alias>csv-validator</alias>
+                                    <build>
+                                        <tags>
+                                            <tag>${docker.tag}</tag>
+                                        </tags>
+                                        <dockerFile>${project.build.outputDirectory}/Dockerfile</dockerFile>
+                                        <contextDir>${assemble.dir}</contextDir>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>build-image</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>push-image</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>push</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/csv-validator-cmd/src/main/resources-filtered/Dockerfile
+++ b/csv-validator-cmd/src/main/resources-filtered/Dockerfile
@@ -1,0 +1,33 @@
+FROM cgr.dev/chainguard/jre:openjdk-17
+
+# Copy CSV Validator
+COPY LICENSE /csv-validator/LICENSE
+COPY lib /csv-validator/lib
+
+
+# Build-time metadata as defined at http://label-schema.org
+# and used by autobuilder @hooks/build
+LABEL org.label-schema.build-date=${maven.build.timestamp} \
+      org.label-schema.description="${project.description}" \
+      org.label-schema.name="CSV Validator" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.url="${project.url}" \
+      org.label-schema.vcs-ref=${build-commit-abbrev} \
+      org.label-schema.vcs-url="${project.scm.url}" \
+      org.label-schema.vendor="The National Archives"
+
+ENV CLASSPATH=/csv-validator/lib/*
+
+ENV JAVA_OPTS \
+  -Dfile.encoding=UTF8 \
+  -Dsun.jnu.encoding=UTF-8 \
+  -Djava.awt.headless=true \
+  -XX:+UseNUMA \
+  -XX:+UseZGC \
+  -XX:+UseStringDeduplication \
+  -XX:+UseContainerSupport \
+  -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE:-75.0} \
+  -XX:+ExitOnOutOfMemoryError
+
+ENTRYPOINT [ "java", \
+    "uk.gov.nationalarchives.csv.validator.cmd.CsvValidatorCmdApp"]


### PR DESCRIPTION
Enabling the `docker` Maven profile by running for example `mvn clean package -Pdocker` will now also create a Docker Image named `nationalarchives/csv-validator` with the default tag `latest`.

You can then use the CSV Validator Command Line Tool as a Docker container, by running:
```
docker run nationalarchives/csv-validator
```