### PR TITLE
DR2-2002 Validate metadata only

### DIFF
--- a/csv-validator-cmd/README.md
+++ b/csv-validator-cmd/README.md
@@ -32,6 +32,8 @@ Usage: validate [options] <csv-path> <csv-schema-path>
         The path to the CSV Schema file to use for validation
   --disable-utf8-validation 
          Disable UTF-8 validation for CSV files
+  --skip-file-checks       
+        Skip integrity, checksum and file existence checks
   --show-progress
          Show progress
   --help

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidator.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidator.scala
@@ -30,11 +30,11 @@ object CsvValidator {
   type PathTo = String
   type SubstitutePath = (PathFrom, PathTo)
 
-  def createValidator(failFast: Boolean, pathSubstitutionsList: List[SubstitutePath], enforceCaseSensitivePathChecksSwitch: Boolean, traceSwitch: Boolean) = {
+  def createValidator(failFast: Boolean, pathSubstitutionsList: List[SubstitutePath], enforceCaseSensitivePathChecksSwitch: Boolean, traceSwitch: Boolean, skipFileChecksSwitch: Boolean) = {
     if(failFast) {
-      new CsvValidator with FailFastMetaDataValidator { val pathSubstitutions = pathSubstitutionsList; val enforceCaseSensitivePathChecks = enforceCaseSensitivePathChecksSwitch; val trace = traceSwitch }
+      new CsvValidator with FailFastMetaDataValidator { val pathSubstitutions = pathSubstitutionsList; val enforceCaseSensitivePathChecks = enforceCaseSensitivePathChecksSwitch; val trace = traceSwitch; val skipFileChecks = skipFileChecksSwitch}
     } else {
-      new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = pathSubstitutionsList; val enforceCaseSensitivePathChecks = enforceCaseSensitivePathChecksSwitch; val trace = traceSwitch }
+      new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = pathSubstitutionsList; val enforceCaseSensitivePathChecks = enforceCaseSensitivePathChecksSwitch; val trace = traceSwitch; val skipFileChecks = skipFileChecksSwitch }
     }
   }
 }

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaParser.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaParser.scala
@@ -49,7 +49,7 @@ with TraceableParsers {
     */
   val enforceCaseSensitivePathChecks: Boolean
 
-
+  val skipFileChecks: Boolean
 
   lazy val versionHeader: PackratParser[String] = "VersionDecl" ::= ("version" ~> versionLiteral )
 
@@ -146,6 +146,7 @@ with TraceableParsers {
     val ecspc = enforceCaseSensitivePathChecks
     val ps =  pathSubstitutions
     val t = trace
+    val sfc = skipFileChecks
 
     SchemaValidator.versionValid(version).map(Failure(_, next)).getOrElse {
       version match {
@@ -153,6 +154,7 @@ with TraceableParsers {
           val parser1_2 = new SchemaParser1_2 {override val enforceCaseSensitivePathChecks: Boolean = ecspc
             override val pathSubstitutions: List[(String, String)] = ps
             override val trace: Boolean = t
+            override val skipFileChecks: Boolean = sfc
           }
 
           parser1_2.parseVersionAware(reader) match {
@@ -165,6 +167,7 @@ with TraceableParsers {
           val parser1_1 = new SchemaParser1_1 {override val enforceCaseSensitivePathChecks: Boolean = ecspc
             override val pathSubstitutions: List[(String, String)] = ps
             override val trace: Boolean = t
+            override val skipFileChecks: Boolean = sfc
           }
 
           parser1_1.parseVersionAware(reader) match {
@@ -177,6 +180,7 @@ with TraceableParsers {
           val parser1_0 = new SchemaParser1_0 {override val enforceCaseSensitivePathChecks: Boolean = ecspc
             override val pathSubstitutions: List[(String, String)] = ps
             override val trace: Boolean = t
+            override val skipFileChecks: Boolean = sfc
           }
 
           parser1_0.parseVersionAware(reader) match {

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParser.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParser.scala
@@ -481,9 +481,9 @@ trait SchemaParser extends BaseSchemaParser {
     */
   lazy val fileExistsExpr: PackratParser[FileExistsRule] = "FileExistsExpr" ::= ("fileExists" ~> opt("(" ~> stringProvider <~ ")")).withFailureMessage("Invalid fileExists rule") ^^ {
     case None =>
-      FileExistsRule(pathSubstitutions, enforceCaseSensitivePathChecks)
+      FileExistsRule(pathSubstitutions, enforceCaseSensitivePathChecks, skipFileChecks = skipFileChecks)
     case Some(s) =>
-      FileExistsRule(pathSubstitutions, enforceCaseSensitivePathChecks, s)
+      FileExistsRule(pathSubstitutions, enforceCaseSensitivePathChecks, s, skipFileChecks = skipFileChecks)
   }
 
 
@@ -492,7 +492,7 @@ trait SchemaParser extends BaseSchemaParser {
     */
   lazy val checksumExpr = "ChecksumExpr" ::= ("checksum(" ~> fileExpr <~ ",") ~ stringLiteral <~ ")" ^^ {
     case files ~ algorithm =>
-      ChecksumRule(files._1.getOrElse(Literal(None)), files._2, algorithm, pathSubstitutions, enforceCaseSensitivePathChecks)
+      ChecksumRule(files._1.getOrElse(Literal(None)), files._2, algorithm, pathSubstitutions, enforceCaseSensitivePathChecks, skipFileChecks)
   }
 
   /**

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/Rule.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/Rule.scala
@@ -66,7 +66,7 @@ case class SwitchRule(elseRules: Option[List[Rule]], cases:(Rule, List[Rule])*) 
 
 
 
-case class IntegrityCheckRule(pathSubstitutions: List[(String,String)], enforceCaseSensitivePathChecks: Boolean, rootPath: ArgProvider = Literal(None), topLevelFolder: String = "content", includeFolder: Boolean = false) extends Rule("integrityCheck", Seq(rootPath): _*) {
+case class IntegrityCheckRule(pathSubstitutions: List[(String,String)], enforceCaseSensitivePathChecks: Boolean, rootPath: ArgProvider = Literal(None), topLevelFolder: String = "content", includeFolder: Boolean = false, skipFileChecks: Boolean = false) extends Rule("integrityCheck", Seq(rootPath): _*) {
 
   //TODO introduce state, not very functional
   var filesMap = Map[String, Set[Path]]()
@@ -83,8 +83,10 @@ case class IntegrityCheckRule(pathSubstitutions: List[(String,String)], enforceC
   }
 
   override def valid(filePath: String, columnDefinition: ColumnDefinition, columnIndex: Int, row: Row, schema: Schema, mayBeLast: Option[Boolean]): Boolean = {
-
-    if (!filePath.isEmpty){
+    if (skipFileChecks) {
+      true
+    }
+    else if (!filePath.isEmpty){
 
         val ruleValue = rootPath.referenceValue(columnIndex, row, schema)
         val filePathS = if (FILE_SEPARATOR == WINDOWS_FILE_SEPARATOR)

--- a/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/SchemaParser.scala
+++ b/csv-validator-core/src/main/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/SchemaParser.scala
@@ -78,9 +78,9 @@ trait SchemaParser extends SchemaParser1_0 {
 
   lazy val integrityCheckExpr: PackratParser[IntegrityCheckRule] = "IntegrityCheckExpr" ::= ("integrityCheck" ~> "(" ~> opt(stringProvider <~ ",") ~ opt(stringLiteral <~ ",") ~ stringLiteral <~ ")"  ).withFailureMessage("Invalid integrityCheck rule") ^^ {
     case rp ~ topLevelFolder ~ includeFolder if (includeFolder == "includeFolder") =>
-      IntegrityCheckRule(pathSubstitutions, enforceCaseSensitivePathChecks, rp.getOrElse(Literal(None)), topLevelFolder.getOrElse("content"), true)
+      IntegrityCheckRule(pathSubstitutions, enforceCaseSensitivePathChecks, rp.getOrElse(Literal(None)), topLevelFolder.getOrElse("content"), true, skipFileChecks)
     case rp ~ topLevelFolder ~ includeFolder if (includeFolder == "excludeFolder") =>
-      IntegrityCheckRule(pathSubstitutions, enforceCaseSensitivePathChecks, rp.getOrElse(Literal(None)), topLevelFolder.getOrElse("content"), false)
+      IntegrityCheckRule(pathSubstitutions, enforceCaseSensitivePathChecks, rp.getOrElse(Literal(None)), topLevelFolder.getOrElse("content"), false, skipFileChecks)
   }
 
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorAcceptanceSpec.scala
@@ -31,6 +31,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     val pathSubstitutions = List[(String,String)]()
     val enforceCaseSensitivePathChecks = false
     val trace = false
+    val skipFileChecks = false
 
     def validateR(csv: io.Reader, schema: Schema): this.type#MetaDataValidation[Any] = validate(csv, schema, None)
   }
@@ -39,6 +40,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
     val pathSubstitutions = List[(String,String)]()
     val enforceCaseSensitivePathChecks = true
     val trace = false
+    val skipFileChecks = false
   }
 
   import v.{validate, validateR, parseSchema}
@@ -406,7 +408,7 @@ class MetaDataValidatorAcceptanceSpec extends Specification with TestResources {
   }
 
   "Validate fail fast" should {
-    val app = new CsvValidator with FailFastMetaDataValidator  { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false }
+    val app = new CsvValidator with FailFastMetaDataValidator  { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false; val skipFileChecks = false }
 
     "only report first error for invalid @TotalColumns" in {
       app.validate(TextFile(Paths.get(base).resolve("totalColumnsFailMetaData.csv")), parse(base + "/totalColumnsSchema.csvs"), None) must beLike {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorBigFileSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorBigFileSpec.scala
@@ -25,14 +25,14 @@ class MetaDataValidatorBigFileSpec extends Specification with TestResources {
   "Big file" should {
 
     "succeed with no stack overflow for all errors" in {
-      val v = new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = List[SubstitutePath](); val enforceCaseSensitivePathChecks = false; val trace = false }
+      val v = new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = List[SubstitutePath](); val enforceCaseSensitivePathChecks = false; val trace = false; val skipFileChecks = false }
       def parse(filePath: String): Schema = v.parseSchema(TextFile(Paths.get(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
 
       v.validate(TextFile(Paths.get(base).resolve("bigMetaData.csv")), parse(base + "/bigSchema.csvs"), None) must beLike { case Validated.Valid(_) => ok }
     }
 
     "succeed with no stack overflow for fail fast" in {
-      val v = new CsvValidator with FailFastMetaDataValidator { val pathSubstitutions = List[SubstitutePath](); val enforceCaseSensitivePathChecks = false; val trace = false }
+      val v = new CsvValidator with FailFastMetaDataValidator { val pathSubstitutions = List[SubstitutePath](); val enforceCaseSensitivePathChecks = false; val trace = false; val skipFileChecks = false }
       def parse(filePath: String): Schema = v.parseSchema(TextFile(Paths.get(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
 
       v.validate(TextFile(Paths.get(base).resolve("bigMetaData.csv")), parse(base + "/bigSchema.csvs"), None) must beLike { case Validated.Valid(_) => ok }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorBusinessAcceptanceSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorBusinessAcceptanceSpec.scala
@@ -22,7 +22,7 @@ class MetaDataValidatorBusinessAcceptanceSpec extends Specification with TestRes
 
   val base = resourcePath("acceptance/dp")
 
-  val v: CsvValidator = new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false }
+  val v: CsvValidator = new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false; val skipFileChecks = false }
   import v.{validate, parseSchema}
 
   def parse(filePath: String): Schema = parseSchema(TextFile(Paths.get(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorChecksumSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorChecksumSpec.scala
@@ -29,6 +29,7 @@ class MetaDataValidatorChecksumSpec extends Specification with TestResources {
       val pathSubstitutions = List[(String,String)]()
       val enforceCaseSensitivePathChecks = false
       val trace = false
+      val skipFileChecks = false
       override def parse(reader: Reader): ParseResult[Schema] = super.parse(reader) match {
         case s @ Success(schema: Schema, _) =>
           s

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorFileCountSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorFileCountSpec.scala
@@ -26,6 +26,7 @@ class MetaDataValidatorFileCountSpec extends Specification with TestResources {
       val pathSubstitutions = List[(String,String)]()
       val enforceCaseSensitivePathChecks = false
       val trace = false
+      val skipFileChecks = false
       override def parse(reader: Reader): ParseResult[Schema] = super.parse(reader) match {
         case s@Success(schema: Schema, _) => s
         case NoSuccess(message, next) => throw new RuntimeException(message)

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorIntegrityCheckSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorIntegrityCheckSpec.scala
@@ -20,10 +20,11 @@ import java.nio.file.Paths
 @RunWith(classOf[JUnitRunner])
 class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResources {
 
-  def buildValidator(substitutionPath: List[(String,String)]) : CsvValidator = new CsvValidator with AllErrorsMetaDataValidator {
+  def buildValidator(substitutionPath: List[(String,String)], skipFileChecksFlag: Boolean = false) : CsvValidator = new CsvValidator with AllErrorsMetaDataValidator {
     val pathSubstitutions = substitutionPath
     val enforceCaseSensitivePathChecks = false
     val trace = false
+    val skipFileChecks = skipFileChecksFlag
   }
 
   def parse(filePath: String, validator: CsvValidator): Schema = validator.parseSchema(TextFile(Paths.get(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
@@ -64,6 +65,15 @@ class MetaDataValidatorIntegrityCheckSpec extends Specification with TestResourc
       //TODO perform test on nonEmptyList instead of using to string
       message.toString  must contain("integrityCheck fails for")
       //      message.toString  must contain("file2 are not listed in ")
+    }
+
+    "succeed for metadatafile missing files if skipFileChecks is true" in {
+
+      val substitutionPaths = List(("file:///T:/WORK/RF_5/", headerPath))
+      val validator = buildValidator(substitutionPaths, true)
+      val result = validator.validate(TextFile(Paths.get(headerPath).resolve("integrityCheckMetaData-missing-files.csv")), parse(headerPath + "/integrityCheckSchema.csvs", validator), None)
+
+      result.isValid mustEqual true
     }
 
     "fail for metadatafile missing files - header" in {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/MetaDataValidatorSpec.scala
@@ -27,6 +27,7 @@ class MetaDataValidatorSpec extends Specification with TestResources {
       val pathSubstitutions = List[(String,String)]()
       val enforceCaseSensitivePathChecks = false
       val trace = false
+      val skipFileChecks = false
       override def parse(reader: Reader): ParseResult[Schema] = {
         super.parse(reader) match {
           case s @ Success(schema: Schema, _) => s

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/NotEmptyBugTest.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/NotEmptyBugTest.scala
@@ -28,7 +28,8 @@ class NotEmptyBugTest extends Specification with TestResources {
       val pathSubstitutions = List[(String,String)]()
       val enforceCaseSensitivePathChecks = false
       val trace = false
-
+      val skipFileChecks = false
+      
       override def parse(reader: Reader): ParseResult[Schema] = {
         super.parse(reader) match {
           case s@Success(schema: Schema, _) => s

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorFileEncodingSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorFileEncodingSpec.scala
@@ -26,7 +26,7 @@ class CsvValidatorFileEncodingSpec extends Specification with TestResources {
 
   "Validation" should {
 
-    val app = new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false }
+    val app = new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false; val skipFileChecks = false }
     def parse(filePath: String): Schema = app.parseSchema(TextFile(Paths.get(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
 
     "fail for non UTF-8 file" in {

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/api/CsvValidatorSpec.scala
@@ -23,7 +23,7 @@ import java.nio.file.Paths
 class CsvValidatorSpec extends Specification with TestResources {
 
   "Parsing schema" should {
-    val app = new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = List[SubstitutePath](); val enforceCaseSensitivePathChecks = false; val trace = false }
+    val app = new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = List[SubstitutePath](); val enforceCaseSensitivePathChecks = false; val trace = false; val skipFileChecks = false }
 
     "report position on parse fail" in {
 
@@ -45,7 +45,7 @@ class CsvValidatorSpec extends Specification with TestResources {
   }
 
   "Validation" should {
-    val app = new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false }
+    val app = new CsvValidator with AllErrorsMetaDataValidator { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false; val skipFileChecks = false }
 
     def parse(filePath: String): Schema = app.parseSchema(TextFile(Paths.get(filePath))) fold (f => throw new IllegalArgumentException(f.toString()), s => s)
 

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaSpecBase.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/SchemaSpecBase.scala
@@ -14,7 +14,7 @@ import uk.gov.nationalarchives.csv.validator.schema.v1_0.NotEmptyRule
 
 trait SchemaSpecBase extends Specification {
 
-  object TestSchemaParser extends SchemaParser { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false }
+  object TestSchemaParser extends SchemaParser { val pathSubstitutions = List[(String,String)](); val enforceCaseSensitivePathChecks = false; val trace = false; val skipFileChecks = false }
 
   def buildSchema1_0(globalDirective: GlobalDirective*)(columnDefinition: ColumnDefinition*) =
     Schema(globalDirective.toList, columnDefinition.toList, "1.0")

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/FileExistsRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/FileExistsRuleSpec.scala
@@ -43,6 +43,10 @@ class FileExistsRuleSpec extends Specification with TestResources {
       }
     }
 
+    "succeed with a non-existent file if skipFileChecks is true" in {
+      FileExistsRule(emptyPathSubstitutions, false, skipFileChecks = true).evaluate(0, Row(List(Cell("some/non/existent/file")), 1), Schema(globalDirsOne, List(ColumnDefinition(NamedColumnIdentifier("column1"))))) must be_==(Validated.Valid(true))
+    }
+
     "fail for empty file path" in {
       FileExistsRule(emptyPathSubstitutions, false).evaluate(1, Row(List(Cell("abc"), Cell("")), 2), Schema(globalDirsTwo, List(ColumnDefinition(NamedColumnIdentifier("column1")), ColumnDefinition(NamedColumnIdentifier("column2"))))) must beLike {
         case Validated.Invalid(messages) => messages.head mustEqual "fileExists fails for line: 2, column: column2, value: \"\""

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserRulesSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_0/SchemaParserRulesSpec.scala
@@ -77,7 +77,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                       @totalColumns 1
                       Name: fileExists"""
 
-      parse(new StringReader(schema)) must beLike { case Success(Schema(_, List(ColumnDefinition(NamedColumnIdentifier("Name"), List(FileExistsRule(emptyPathSubs, false, Literal(None))), _)), _), _) => ok }
+      parse(new StringReader(schema)) must beLike { case Success(Schema(_, List(ColumnDefinition(NamedColumnIdentifier("Name"), List(FileExistsRule(emptyPathSubs, false, Literal(None), false)), _)), _), _) => ok }
     }
 
 //    "fail for file exists rule with empty ()" in {
@@ -94,7 +94,7 @@ class SchemaParserRulesSpec extends SchemaSpecBase {
                       Name: fileExists("some/root/path")"""
 
       parse(new StringReader(schema)) must beLike {
-        case Success(Schema(_, List(ColumnDefinition(NamedColumnIdentifier("Name"), List(FileExistsRule(emptyPathSubs, false, Literal(Some(rootPath)))), _)), _), _) => {
+        case Success(Schema(_, List(ColumnDefinition(NamedColumnIdentifier("Name"), List(FileExistsRule(emptyPathSubs, false, Literal(Some(rootPath)), false)), _)), _), _) => {
           rootPath mustEqual "some/root/path"
         }
       }

--- a/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/IntegrityCheckRuleSpec.scala
+++ b/csv-validator-core/src/test/scala/uk/gov/nationalarchives/csv/validator/schema/v1_1/IntegrityCheckRuleSpec.scala
@@ -70,6 +70,15 @@ class IntegrityCheckRuleSpec extends Specification with TestResources {
       }
     }
 
+    "succeed for empty file path if skipFileChecks is true" in {
+      val integrityCheckRule = IntegrityCheckRule(emptyPathSubstitutions, false, skipFileChecks = true)
+      val schema: Schema = Schema(globalDirsTwo, List(ColumnDefinition(NamedColumnIdentifier("column1")), ColumnDefinition(NamedColumnIdentifier("column2"))))
+
+      integrityCheckRule.evaluate(1, Row(List(Cell("abc"), Cell(relIntegrityCheckForRulePath)), 1), schema, Some(true)) mustEqual Validated.Valid(true)
+
+      integrityCheckRule.evaluate(1, Row(List(Cell("abc"), Cell("")), 2), schema, Some(false)) mustEqual Validated.Valid(true)
+    }
+
     "succeed for file that exists with no root file path" in {
 
       val integrityCheckRule = IntegrityCheckRule(emptyPathSubstitutions,false)

--- a/csv-validator-java-api/src/main/scala/uk/gov/nationalarchives/csv/validator/api/java/CsvValidatorJavaBridge.scala
+++ b/csv-validator-java-api/src/main/scala/uk/gov/nationalarchives/csv/validator/api/java/CsvValidatorJavaBridge.scala
@@ -29,27 +29,27 @@ object CsvValidatorJavaBridge {
 
   @deprecated
   def validate(csvFile: String, csvEncoding: Charset, csvSchemaFile: String, csvSchemaEncoding: Charset, failFast: Boolean, pathSubstitutionsList: JList[Substitution], enforceCaseSensitivePathChecks: Boolean, trace: Boolean): JList[FailMessage] =
-    validate(csvFile, csvEncoding, true, csvSchemaFile, csvSchemaEncoding, false, failFast, pathSubstitutionsList, enforceCaseSensitivePathChecks, trace, None)
+    validate(csvFile, csvEncoding, true, csvSchemaFile, csvSchemaEncoding, false, failFast, pathSubstitutionsList, enforceCaseSensitivePathChecks, trace, None, false)
 
   @deprecated
   def validate(csvFile: String, csvEncoding: Charset, csvSchemaFile: String, csvSchemaEncoding: Charset, failFast: Boolean, pathSubstitutionsList: JList[Substitution], enforceCaseSensitivePathChecks: Boolean, trace: Boolean, progress: ProgressCallback): JList[FailMessage] = {
     val sProgressCallback = new SProgressCallback {
       override def update(complete: this.type#Percentage) = progress.update(complete)
     }
-    validate(csvFile, csvEncoding, true, csvSchemaFile, csvSchemaEncoding, false, failFast, pathSubstitutionsList, enforceCaseSensitivePathChecks, trace, Some(sProgressCallback))
+    validate(csvFile, csvEncoding, true, csvSchemaFile, csvSchemaEncoding, false, failFast, pathSubstitutionsList, enforceCaseSensitivePathChecks, trace, Some(sProgressCallback), false)
   }
 
   def validate(csvFile: String, csvEncoding: Charset, validateCsvEncoding: Boolean, csvSchemaFile: String, csvSchemaEncoding: Charset, validateCsvSchemaEncoding: Boolean, failFast: Boolean, pathSubstitutionsList: JList[Substitution], enforceCaseSensitivePathChecks: Boolean, trace: Boolean): JList[FailMessage] =
-    validate(csvFile, csvEncoding, validateCsvEncoding, csvSchemaFile, csvSchemaEncoding, validateCsvSchemaEncoding, failFast, pathSubstitutionsList, enforceCaseSensitivePathChecks, trace, None)
+    validate(csvFile, csvEncoding, validateCsvEncoding, csvSchemaFile, csvSchemaEncoding, validateCsvSchemaEncoding, failFast, pathSubstitutionsList, enforceCaseSensitivePathChecks, trace, None, false)
 
   def validate(csvFile: String, csvEncoding: Charset, validateCsvEncoding: Boolean, csvSchemaFile: String, csvSchemaEncoding: Charset, validateCsvSchemaEncoding: Boolean, failFast: Boolean, pathSubstitutionsList: JList[Substitution], enforceCaseSensitivePathChecks: Boolean, trace: Boolean, progress: ProgressCallback): JList[FailMessage] = {
     val sProgressCallback = new SProgressCallback {
       override def update(complete: this.type#Percentage) = progress.update(complete)
     }
-    validate(csvFile, csvEncoding, validateCsvEncoding, csvSchemaFile, csvSchemaEncoding, validateCsvSchemaEncoding, failFast, pathSubstitutionsList, enforceCaseSensitivePathChecks, trace, Some(sProgressCallback))
+    validate(csvFile, csvEncoding, validateCsvEncoding, csvSchemaFile, csvSchemaEncoding, validateCsvSchemaEncoding, failFast, pathSubstitutionsList, enforceCaseSensitivePathChecks, trace, Some(sProgressCallback), false)
   }
 
-  private def validate(csvFile: String, csvEncoding: Charset, validateCsvEncoding: Boolean, csvSchemaFile: String, csvSchemaEncoding: Charset, validateCsvSchemaEncoding: Boolean, failFast: Boolean, pathSubstitutionsList: JList[Substitution], enforceCaseSensitivePathChecks: Boolean, trace: Boolean, progress: Option[SProgressCallback]): JList[FailMessage] = {
+  private def validate(csvFile: String, csvEncoding: Charset, validateCsvEncoding: Boolean, csvSchemaFile: String, csvSchemaEncoding: Charset, validateCsvSchemaEncoding: Boolean, failFast: Boolean, pathSubstitutionsList: JList[Substitution], enforceCaseSensitivePathChecks: Boolean, trace: Boolean, progress: Option[SProgressCallback], skipFileChecks: Boolean): JList[FailMessage] = {
 
     import scala.jdk.CollectionConverters._
 
@@ -63,7 +63,7 @@ object CsvValidatorJavaBridge {
         errors.map{ asJavaMessage(_) }.toList.asJava
 
       case Validated.Valid(_) =>
-        val validator = createValidator(failFast, pathSubs, enforceCaseSensitivePathChecks, trace)
+        val validator = createValidator(failFast, pathSubs, enforceCaseSensitivePathChecks, trace, skipFileChecks)
         validator.parseSchema(csvSchemaTextFile) match {
 
           case Validated.Invalid(errors) =>
@@ -88,13 +88,13 @@ object CsvValidatorJavaBridge {
     validate(csvData, csvSchema, failFast, pathSubstitutionsList, enforceCaseSensitivePathChecks, trace, Some(sProgressCallback))
   }
 
-  private def validate(csvData: JReader, csvSchema: JReader, failFast: Boolean, pathSubstitutionsList: JList[Substitution],  enforceCaseSensitivePathChecks: Boolean, trace: Boolean, progress: Option[SProgressCallback]): JList[FailMessage] = {
+  private def validate(csvData: JReader, csvSchema: JReader, failFast: Boolean, pathSubstitutionsList: JList[Substitution],  enforceCaseSensitivePathChecks: Boolean, trace: Boolean, progress: Option[SProgressCallback], skipFileChecks: Boolean = false): JList[FailMessage] = {
 
     import scala.jdk.CollectionConverters._
 
     val pathSubs: List[(String,String)] = pathSubstitutionsList.asScala.map( x => (x.getFrom, x.getTo)).toList
-
-    val validator = createValidator(failFast, pathSubs, enforceCaseSensitivePathChecks, trace)
+    
+    val validator = createValidator(failFast, pathSubs, enforceCaseSensitivePathChecks, trace, skipFileChecks)
     validator.parseSchema(csvSchema) match {
 
       case Validated.Invalid(errors) =>

--- a/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
+++ b/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
@@ -369,7 +369,7 @@ object CsvValidatorUi extends SimpleSwingApplication {
 
 
     btnValidate.reactions += validateOnClick(btnValidate, false)
-    btnValidateMetadataOnly.reactions += validateOnClick(btnValidate, true)
+    btnValidateMetadataOnly.reactions += validateOnClick(btnValidateMetadataOnly, true)
 
     private def validateOnClick(button: Button, skipFileChecks: Boolean) = {
       val suffix = if(skipFileChecks) " (Metadata Only)" else ""

--- a/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
+++ b/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
@@ -368,14 +368,15 @@ object CsvValidatorUi extends SimpleSwingApplication {
       }
 
 
-    btnValidate.reactions += validateOnClick(btnValidate, false)
-    btnValidateMetadataOnly.reactions += validateOnClick(btnValidateMetadataOnly, true)
+    btnValidate.reactions += validateOnClick(false)
+    btnValidateMetadataOnly.reactions += validateOnClick(true)
 
-    private def validateOnClick(button: Button, skipFileChecks: Boolean) = {
+    private def validateOnClick(skipFileChecks: Boolean) = {
       val suffix = if(skipFileChecks) " (Metadata Only)" else ""
       onClick(displayWait(
         suspendUi = {
-          button.enabled = false
+          btnValidate.enabled = false
+          btnValidateMetadataOnly.enabled = false
           this.peer.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR))
           this.progressBar.value = 0
           this.progressBar.visible = true
@@ -400,7 +401,9 @@ object CsvValidatorUi extends SimpleSwingApplication {
         output = outputToReport,
         resumeUi = {
           btnValidate.enabled = true
-          this.peer.setCursor(Cursor.getDefaultCursor)
+          btnValidateMetadataOnly.enabled = true
+          btnValidate.peer.setCursor(Cursor.getDefaultCursor)
+          btnValidateMetadataOnly.peer.setCursor(Cursor.getDefaultCursor)
           //this.progressBar.visible = false
         }
       ))


### PR DESCRIPTION
This allows you to skip the file exists, checksum and integrity checks
which you may need if you have a draft metadata file without the files
themselves.

I've added a button in the UI, an argument in the CLI and an option in
the Java bridge.
