### PR TITLE
Fix cursor continuing to spin after validation

### DIFF
--- a/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
+++ b/csv-validator-ui/src/main/scala/uk/gov/nationalarchives/csv/validator/ui/CsvValidatorUi.scala
@@ -421,8 +421,7 @@ object CsvValidatorUi extends SimpleSwingApplication {
           resumeUi = {
             btnValidate.enabled = true
             btnValidateMetadataOnly.enabled = true
-            btnValidate.peer.setCursor(Cursor.getDefaultCursor)
-            btnValidateMetadataOnly.peer.setCursor(Cursor.getDefaultCursor)
+            this.peer.setCursor(Cursor.getDefaultCursor)
           }
         )
       } else doNothingOnClick()


### PR DESCRIPTION
This was accidentally introduced in the '[Disable both buttons when either is pressed](https://github.com/digital-preservation/csv-validator/pull/515/commits/c4faf4c902df8e196a747678a4156a3f070ad267)' commit of the 'DR2-2002 Validate metadata only' PR; this commit reverts it.