### PR TITLE
Make `ValidatorBuilder` class visible outside the package

### DIFF
--- a/csv-validator-java-api/src/main/java/uk/gov/nationalarchives/csv/validator/api/java/CsvValidator.java
+++ b/csv-validator-java-api/src/main/java/uk/gov/nationalarchives/csv/validator/api/java/CsvValidator.java
@@ -195,7 +195,7 @@ public class CsvValidator {
         return CsvValidatorJavaBridge.validate(csvData, csvSchema, failFast, pathSubstitutions, enforceCaseSensitivePathChecks, trace, progress);
     }
 
-    static class ValidatorBuilder {
+    public static class ValidatorBuilder {
         private String csvFileName;
         private String csvSchemaFilename;
         private Reader csvReader;


### PR DESCRIPTION
This PR fixes the inconsistency in `ValidatorBuilder` Accessibility, in the documentation it was marked as public and should be used instead of the deprecated `validate` functions yet in the actual implementation it's package private.

Fixes #609.
